### PR TITLE
Clean up Code of Conduct links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,8 +6,7 @@ Everyone is expected to follow the [Scala Code of Conduct] when discussing the p
 
 ## Moderation
 
-Any questions, concerns, or moderation requests please contact a member of the project.
+Any questions, concerns, or moderation requests please contact a [member of the project][moderators].
 
-- [Christopher Davenport](mailto:chris@christopherdavenport.tech)
-
-[Scala Code of Conduct]: https://www.scala-lang.org/conduct/
+[Scala Code of Conduct]: https://http4s.org/code-of-conduct/
+[moderators]: https://http4s.org/code-of-conduct/#moderation


### PR DESCRIPTION
1. Link to http4s' copy, because it has our moderators
2. Link to our moderators, so if we add and remove any, it's not a pain as we go polyrepo

I'm assuming for now that moderators will be from the organization pool, even if individual modules get their own committers.