### PR TITLE
Explicitly use xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: false
 language: scala
 


### PR DESCRIPTION
Trusty hit EOL on April 30,  2019, and it's still ambiguous what Travis CI's default is.