### PR TITLE
Semi-colons aren't needed from the shell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
       jdk: *java_11
       scala: *scala_version_docs
       script:
-        - sbt ++$TRAVIS_SCALA_VERSION ;+publishSigned ;docs/makeSite ;docs/ghpagesPushSite
+        - sbt ++$TRAVIS_SCALA_VERSION +publishSigned docs/makeSite docs/ghpagesPushSite
 
 cache:
   directories:


### PR DESCRIPTION
This is why the [master publish is failing.](https://travis-ci.com/http4s/http4s-jdk-http-client/jobs/202380021#L231)