### PR TITLE
Test scaladoc on each build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,16 @@ java11: &java_11 openjdk11
 java12: &java_12 openjdk12
 
 stages:
-  - name: test
+  - name: tests
   - name: publish
     if: (branch = master AND type = push)
 
 jobs:
   include:
     - &tests
-      env: TEST="test"
+      env: TEST="tests"
       script:
-        - sbt ++$TRAVIS_SCALA_VERSION test
-        - sbt ++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues
-        - sbt ++$TRAVIS_SCALA_VERSION scalafmtCheckAll        
+        - sbt ++$TRAVIS_SCALA_VERSION test doc mimaReportBinaryIssues scalafmtCheckAll
       scala: *scala_version_211
       jdk: *java_11
     - <<: *tests
@@ -33,7 +31,7 @@ jobs:
       scala: *scala_version_212
       jdk: *java_12
 
-    - env: TEST="docs"
+    - env: TEST="site"
       scala: *scala_version_docs
       script:
         - sbt ++$TRAVIS_SCALA_VERSION docs/makeSite


### PR DESCRIPTION
Can't publish to Sonatype without it, so we should be testing it on every cross build.  See #22.