### PR TITLE
Overhaul release process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ java12: &java_12 openjdk12
 stages:
   - name: tests
   - name: publish
-    if: (branch = master AND type = push)
+    if: (branch = master AND type = push AND tag IS blank)
+  - name: release
+    if: tag IS present
 
 jobs:
   include:
@@ -48,7 +50,15 @@ jobs:
         - eval "$(ssh-agent -s)"
         - echo $SSH_PRIVATE_KEY | base64 --decode | ssh-add -
       script:
-        - sbt ++$TRAVIS_SCALA_VERSION +publishSigned docs/makeSite docs/ghpagesPushSite
+        - sbt ++$TRAVIS_SCALA_VERSION +publishSigned
+      after_success:
+        - sbt ++$TRAVIS_SCALA_VERSION docs/makeSite docs/ghpagesPushSite
+
+    - <<: *tests
+      stage: release
+      env: TEST="release"
+      script:
+        - sbt ++$TRAVIS_SCALA_VERSION sonatypeOpen +publishSigned sonatypeRelease
 
 cache:
   directories:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,3 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.5.4")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.1.0-SNAPSHOT"


### PR DESCRIPTION
The good:

* Uses git versioning.  The version number is set by a tag.  If it is not a tagged build, it's set to the base version, plus the SHA, plus `-SNAPSHOT`.  For instance, this version is `0.1.0-3e20680a711b8844c7d51d0ecfdcb1261472f89d-SNAPSHOT`.  If I tagged and pushed `v0.1.0`, the resulting build would be version `0.1.0`.

* Adds a `release` stage, executed only on tags.  This is identical to the `publish` stage, but wraps the command in `sonatypeOpen` and `sonatypeRelease`.  This is an improvement on `sonatypeReleaseAll`, which interferes with other projects in the organization being released at the same time.

* Eliminates sbt-release.  Special behavior is now driven by tags, and Travis CI no longer commits to git except to publish the site.  This is a source of failed release builds when changes are happening quickly.

The bad:

* We have to bump the baseVersion to get sensible snapshot definitions.

* Nothing checks tags for snapshot dependencies, though we could scavenge this code.

* Nothing checks that the tag matches the base version, though we could add that if we're afraid of typos in a tag.

* There's no pull request that signifies a release. 