### PR TITLE
Fix supported Scala versions in docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -205,7 +205,7 @@ lazy val docsSettings = {
       "VERSION" -> version.value,
       "BINARY_VERSION" -> binaryVersion(version.value),
       "HTTP4S_VERSION" -> http4sV,
-      "SCALA_VERSIONS" -> formatCrossScalaVersions(crossScalaVersions.value.toList)
+      "SCALA_VERSIONS" -> formatCrossScalaVersions((core / crossScalaVersions).value.toList)
     ),
     scalacOptions in mdoc --= Seq(
       "-Xfatal-warnings",


### PR DESCRIPTION
When we added the cross build override for docs, we broke this.