### PR TITLE
Update coursier cache location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,6 @@ jobs:
 
 cache:
   directories:
+    - $HOME/.cache
     - $HOME/.ivy2/cache
-    - $HOME/.coursier/cache
     - $HOME/.sbt


### PR DESCRIPTION
https://www.scala-sbt.org/1.x/docs/Travis-CI-with-sbt.html#Caching

But I see no reason not to do all of .cache for futureproofing.