### PR TITLE
Upgrade to http4s-0.21.0-RC1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This file summarizes **notable** changes for each release, but does not describe
 
 ----
 
+## v0.2.0-RC2 (2020-01-22)
+
+### Dependency updates
+
+* http4s-0.21.0-RC1
+
 ## v0.2.0-RC1 (2020-01-22)
 
 ### Enhancements
@@ -14,7 +20,6 @@ This file summarizes **notable** changes for each release, but does not describe
 
 * cats-2.1.0
 * fs2-2.2.1
-* http4s-0.21.0-RC1
 
 ## v0.2.0-M4 (2019-12-01)
 

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ val catsV = "2.1.0"
 val catsEffectV = "2.0.0"
 val fs2V = "2.2.1"
 val scodecV = "1.1.12"
-val http4sV = "0.21.0-M6"
+val http4sV = "0.21.0-RC1"
 val reactiveStreamsV = "1.0.3"
 val vaultV = "2.0.0"
 


### PR DESCRIPTION
We missed the most important upgrade of all. I'll release this as 0.2.0-RC2.