### PR TITLE
fix site publishing

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -28,6 +28,7 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SBT_GHPAGES_COMMIT_MESSAGE: 'Updated site: sha=${{ github.sha }} build=${{ github.action }}'
         run: |
           mkdir ~/.gnupg && chmod 700 ~/.gnupg
           echo use-agent >> ~/.gnupg/gpg.conf
@@ -38,4 +39,7 @@ jobs:
           echo "$PGP_SECRET" | base64 --decode | gpg --import --no-tty --batch --yes
           eval "$(ssh-agent -s)"
           echo "$SSH_PRIVATE_KEY" | ssh-add -
+          git config --global user.name "GitHub Actions CI"
+          git config --global user.email "ghactions@invalid"
+
           sbt +publishSigned docs/makeSite docs/ghpagesPushSite

--- a/build.sbt
+++ b/build.sbt
@@ -270,14 +270,6 @@ lazy val docsSettings = {
       target.value / "netlify.toml" -> "netlify.toml",
     ),
 
-    ghpagesCommitOptions := {
-      val sha = sys.env.getOrElse("GITHUB_SHA", "???")
-      val build = sys.env.getOrElse("GITHUB_ACTION", "???")
-      List(
-        s"--author=GitHub Actions CI <ghactions@invalid>",
-        "-m", s"Updated site: sha=${sha} build=${build}"
-      )
-    },
     includeFilter in ghpagesCleanSite :=
       new FileFilter{
         def accept(f: File) =


### PR DESCRIPTION
Site publishing did not work previously (see [gh-pages log](https://github.com/http4s/http4s-jdk-http-client/commits/gh-pages), [error message](https://github.com/http4s/http4s-jdk-http-client/runs/421426336?check_suite_focus=true#step:6:119)).

I am not sure why this fails (the job does not fail as sbt-ghpages [swallows the error](https://github.com/sbt/sbt-ghpages/blob/master/src/main/scala/com/typesafe/sbt/sbtghpages/GhpagesPlugin.scala#L95-L98)), but this workaround does work, and I think it is in fact "better" that local publishing uses the local github user information and not "GitHub Actions CI". The commit message for local publishing will be "updated site" ([src](https://github.com/sbt/sbt-ghpages/blob/master/src/main/scala/com/typesafe/sbt/sbtghpages/GhpagesPlugin.scala#L85)).