### PR TITLE
Move sonatypeBundleRelease step

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,12 +93,11 @@ lazy val releaseSettings = {
       setReleaseVersion,
       commitReleaseVersion,
       tagRelease,
-      // For non cross-build projects, use releaseStepCommand("publishSigned")
       releaseStepCommandAndRemaining("+publishSigned"),
+      releaseStepCommand("sonatypeBundleRelease"),
       releaseStepCommand("docs/ghpagesPushSite"),
       setNextVersion,
       commitNextVersion,
-      releaseStepCommand("sonatypeBundleRelease"),
       pushChanges
     ),
     publishTo := {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.0-SNAPSHOT"
+version in ThisBuild := "0.2.0-RC5"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.0-RC5"
+version in ThisBuild := "0.2.0-SNAPSHOT"


### PR DESCRIPTION
Move sonatypeBundleRelease ahead of bumping the version number, or else it fails to find the bundle to release.

Move it ahead of site publication, so we don't advertise a release that doesn't exist. (Even though we'll still advertise it before it syncs to Maven Central.)