### PR TITLE
Missing changelog for 0.2.0-RC5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This file summarizes **notable** changes for each release, but does not describe
 
 ----
 
+## v0.2.0-RC5 (2020-02-03)
+
+This release is fully source compatible with v0.2.0-RC4, but has a binary-incompatible dependency on http4s.
+
+### Dependency updates
+
+* http4s-0.21.0-RC3
+
 ## v0.2.0-RC4 (2020-02-01)
 
 This release is fully source compatible with v0.2.0-RC2, but has a binary-incompatible dependency on http4s.


### PR DESCRIPTION
I should have done this before the release.  

In the http4s-core repo, there is a single changelog, but it leads to a complicated split process between shared pages and version-specific pages.  We only have the latter, which simplifies publishing, but makes it hard to correct docs after the tag like this.  Something to ponder.