### PR TITLE
change caching strategy & use actual build number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,22 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+      - name: Get current week
+        run: |
+          echo "::set-env name=current_week::$(( $(date +%U) ))"
+          echo "::set-env name=last_week::$(( $(date +%U) - 1 ))"
       - name: Cache SBT coursier cache
         uses: actions/cache@v1
         with:
           path: ~/.cache/coursier
-          key: sbt-coursier-cache
+          key: coursier-${{ env.current_week }}
+          restore-keys: coursier-${{ env.last_week }}
       - name: Cache SBT
         uses: actions/cache@v1
         with:
           path: ~/.sbt
-          key: sbt-${{ hashFiles('**/build.sbt') }}
+          key: sbt-${{ env.current_week }}
+          restore-keys: sbt-${{ env.last_week }}
       - name: Tests
         run: sbt ++$SCALA_VERSION test doc mimaReportBinaryIssues scalafmtCheckAll
       - name: Test docs

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -12,16 +12,22 @@ jobs:
         with:
           java-version: 11
       - uses: olafurpg/setup-gpg@v2
+      - name: Get current week
+        run: |
+          echo "::set-env name=current_week::$(( $(date +%U) ))"
+          echo "::set-env name=last_week::$(( $(date +%U) - 1 ))"
       - name: Cache SBT coursier cache
         uses: actions/cache@v1
         with:
           path: ~/.cache/coursier
-          key: sbt-coursier-cache
+          key: coursier-${{ env.current_week }}
+          restore-keys: coursier-${{ env.last_week }}
       - name: Cache SBT
         uses: actions/cache@v1
         with:
           path: ~/.sbt
-          key: sbt-${{ hashFiles('**/build.sbt') }}
+          key: sbt-${{ env.current_week }}
+          restore-keys: sbt-${{ env.last_week }}
       - name: Publish snapshot
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -29,7 +35,7 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          SBT_GHPAGES_COMMIT_MESSAGE: 'Updated site: sha=${{ github.sha }} build=${{ github.action }}'
+          SBT_GHPAGES_COMMIT_MESSAGE: 'Updated site: sha=${{ github.sha }} build=${{ github.run_id }}'
         run: |
           echo "$PGP_SECRET" | base64 --decode | gpg --import --no-tty --batch --yes
           eval "$(ssh-agent -s)"


### PR DESCRIPTION
 - We now use `github.run_id` instead of `github.action`
 - We use a weekly cache that uses the cache of the week before. This way, we always have a reasonably fresh cache which neither does grow without bounds nor does reset if any sbt or project/*.scala file is changed.