### PR TITLE
use upickle instead of circe in sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,18 +41,16 @@ val javaWebsocketV = "1.4.1"
 val kindProjectorV = "0.10.3"
 val betterMonadicForV = "0.3.1"
 
-lazy val scalaVersions = {
-  import cats.data.NonEmptyList
-  val str = scala.io.Source.fromFile("scalaVersions.json").mkString
-  _root_.io.circe.parser.decode[NonEmptyList[String]](str).fold(throw _, identity)
-}
+lazy val scalaVersions =
+  upickle.default.read[List[String]](new File("scalaVersions.json"))
+
 
 // General Settings
 lazy val commonSettings = Seq(
   organization := "org.http4s",
 
   scalaVersion := scalaVersions.head,
-  crossScalaVersions := scalaVersions.toList.toSeq,
+  crossScalaVersions := scalaVersions,
   scalacOptions += "-Yrangepos",
 
   scalacOptions in (Compile, doc) ++= Seq(

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,3 +1,3 @@
 libraryDependencies ++= Seq(
-  "io.circe" %% "circe-parser" % "0.13.0"
+  "com.lihaoyi" %% "upickle" % "0.9.5"
 )


### PR DESCRIPTION
paradox-material-theme uses an ancient circe version (jonas/paradox-material-theme#25). Downgrading circe results in jawn conflicts.

I initially suggested temporarily not using this theme, but I ran into other issues there too... [gitter](https://gitter.im/http4s/http4s-dev?at=5e850f164ed72e126b8a3044)

This should fix snapshot publishing.