### PR TITLE
workaround for #200

### DIFF
--- a/core/src/main/scala/org/http4s/client/jdkhttpclient/JdkWSClient.scala
+++ b/core/src/main/scala/org/http4s/client/jdkhttpclient/JdkWSClient.scala
@@ -139,5 +139,5 @@ object JdkWSClient {
 
   /** A `WSClient` wrapping the default `HttpClient`. */
   def simple[F[_]](implicit F: ConcurrentEffect[F], CS: ContextShift[F]): F[WSClient[F]] =
-    F.delay(HttpClient.newHttpClient()).map(apply(_))
+    JdkHttpClient.defaultHttpClient[F].map(apply(_))
 }

--- a/core/src/test/scala/org/http4s/client/jdkhttpclient/DeadlockWorkaround.scala
+++ b/core/src/test/scala/org/http4s/client/jdkhttpclient/DeadlockWorkaround.scala
@@ -1,0 +1,35 @@
+package org.http4s.client.jdkhttpclient
+
+import javax.net.ssl.SSLHandshakeException
+
+import cats.effect._
+import cats.effect.testing.specs2.CatsIO
+import org.http4s.implicits._
+import org.specs2.mutable.Specification
+
+class DeadlockWorkaround extends Specification with CatsIO {
+
+  "The clients" should {
+    "fail to connect via TLSv1.3 on Java 11" in {
+      if (Runtime.version().feature() > 11) IO.pure(true)
+      else
+        for {
+          http <- JdkHttpClient.simple[IO]
+          ws <- JdkWSClient.simple[IO]
+          testSSLFailure =
+            (r: IO[Unit]) =>
+              r.redeem(
+                recover = {
+                  case _: SSLHandshakeException => true
+                  case e => throw e
+                },
+                map = _ => false
+              )
+          a <- testSSLFailure(http.expect[Unit](uri"https://tls13.1d.pw"))
+          b <-
+            testSSLFailure(ws.connectHighLevel(WSRequest(uri"wss://tls13.1d.pw")).use(_ => IO.unit))
+        } yield a && b
+    }
+  }
+
+}

--- a/docs/src/main/mdoc/index.md
+++ b/docs/src/main/mdoc/index.md
@@ -25,13 +25,9 @@ libraryDependencies ++= Seq(
 * Built for Scala @SCALA_VERSIONS@
 * Works with http4s-client-@HTTP4S_VERSION@
 
-@@@warning { title='TLS 1.3 on Java 11' }
-On Java 11, you might experience very spurious deadlocks if you use TLS 1.3
-which is enabled by default. See [here](https://github.com/http4s/http4s-jdk-http-client/issues/200)
-for a report.
-
-You can work around this by using a [custom client](#custom-clients)
-with TLS 1.3 disabled or by upgrading to a Java version > 11.
+@@@note { title='TLS 1.3 on Java 11' }
+On Java 11, TLS 1.3 is disabled by default (when using `JdkHttpClient.simple`).
+This is a workaround for a spurious bug, see [#200](https://github.com/http4s/http4s-jdk-http-client/issues/200).
 @@@
 
 ### Creating the client


### PR DESCRIPTION
Frankly, I don't have the motiviation to debug #200 again. I just pray that this bug magically disappears by a Java 11 or cats-effect update.

The only people who are negatively affected by this change are people who use a default client to connect to a server which only supports TLSv1.3 on Java 11 (mentioning the `SSLHandshakeException` here so that it can be googled). I think this is pretty rare.

Please intervene if you liked the previous state (warning in the docs, no built-in workaround) more. Personally, I am very slightly in favor of this PR.

Closes #200