### PR TITLE
Some CI tweaks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,26 +9,11 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
-    - name: Get current week
-      run: |
-        echo "::set-env name=current_week::$(( 10#$(date +%U) ))"
-        echo "::set-env name=last_week::$(( 10#$(date +%U) - 1 ))"
-    - name: Cache SBT coursier cache
-      uses: actions/cache@v1
-      with:
-        key: coursier-${{ env.current_week }}
-        path: ~/.cache/coursier
-        restore-keys: coursier-${{ env.last_week }}
-    - name: Cache SBT
-      uses: actions/cache@v1
-      with:
-        key: sbt-${{ env.current_week }}
-        path: ~/.sbt
-        restore-keys: sbt-${{ env.last_week }}
-    - name: Unused and undeclared dependencies
-      run: sbt ++$SCALA_VERSION unusedCompileDependenciesTest undeclaredCompileDependenciesTest
+    - uses: coursier/cache-action@v5
     - name: Tests
       run: sbt ++$SCALA_VERSION test
+    - name: Unused and undeclared dependencies
+      run: sbt ++$SCALA_VERSION unusedCompileDependenciesTest undeclaredCompileDependenciesTest
     - name: Scaladocs
       run: sbt ++$SCALA_VERSION doc
     - name: MiMa
@@ -43,7 +28,7 @@ jobs:
       matrix:
         java:
         - '11'
-        - '14'
+        - '15'
         scala:
         - 2.12.12
         - 2.13.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,22 +9,7 @@ jobs:
       with:
         java-version: '11'
     - uses: olafurpg/setup-gpg@v2
-    - name: Get current week
-      run: |
-        echo "::set-env name=current_week::$(( 10#$(date +%U) ))"
-        echo "::set-env name=last_week::$(( 10#$(date +%U) - 1 ))"
-    - name: Cache SBT coursier cache
-      uses: actions/cache@v1
-      with:
-        key: coursier-${{ env.current_week }}
-        path: ~/.cache/coursier
-        restore-keys: coursier-${{ env.last_week }}
-    - name: Cache SBT
-      uses: actions/cache@v1
-      with:
-        key: sbt-${{ env.current_week }}
-        path: ~/.sbt
-        restore-keys: sbt-${{ env.last_week }}
+    - uses: coursier/cache-action@v5
     - env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,7 +6,7 @@ pull_request_rules:
   - author=scala-steward
   - body~=labels:.*semver-patch.*
   - status-success=Scala 2.12.12, Java 11
-  - status-success=Scala 2.12.12, Java 14
+  - status-success=Scala 2.12.12, Java 15
   - status-success=Scala 2.13.3, Java 11
-  - status-success=Scala 2.13.3, Java 14
+  - status-success=Scala 2.13.3, Java 15
   name: automatically merge scala-steward's PRs

--- a/dhall/ci.dhall
+++ b/dhall/ci.dhall
@@ -2,35 +2,37 @@ let c = ./common.dhall
 
 let steps =
       let sbtStep =
-                \(run : c.Run.Type)
-            ->  c.BuildStep.Run
-                  (run // { run = "sbt ++\$SCALA_VERSION ${run.run}" })
+            \(run : c.Run.Type) ->
+              c.BuildStep.Run
+                (run // { run = "sbt ++\$SCALA_VERSION ${run.run}" })
 
       let sbtSimpleStep =
-                \(name : Text)
-            ->  \(task : Text)
-            ->  sbtStep c.Run::{ name = name, run = task }
+            \(name : Text) ->
+            \(task : Text) ->
+              sbtStep c.Run::{ name, run = task }
 
-      in    [ c.steps.checkout, c.steps.java "\${{ matrix.java }}" ]
-          # c.steps.cache
-          # [ sbtSimpleStep
-                "Unused and undeclared dependencies"
-                "unusedCompileDependenciesTest undeclaredCompileDependenciesTest"
-            , sbtSimpleStep "Tests" "test"
-            , sbtSimpleStep "Scaladocs" "doc"
-            , sbtSimpleStep "MiMa" "mimaReportBinaryIssues"
-            , sbtSimpleStep "Scalafmt" "scalafmtCheckAll scalafmtSbtCheck"
-            , sbtStep
-                c.Run::{
-                , name = "Test docs"
-                , run = "docs/makeSite"
-                , `if` = Some "startsWith(matrix.scala, '2.12')"
-                }
-            ]
+      in  [ c.steps.checkout
+          , c.steps.java "\${{ matrix.java }}"
+          , c.steps.cache
+          , sbtSimpleStep "Tests" "test"
+          , sbtSimpleStep
+              "Unused and undeclared dependencies"
+              "unusedCompileDependenciesTest undeclaredCompileDependenciesTest"
+          , sbtSimpleStep "Scaladocs" "doc"
+          , sbtSimpleStep "MiMa" "mimaReportBinaryIssues"
+          , sbtSimpleStep "Scalafmt" "scalafmtCheckAll scalafmtSbtCheck"
+          , sbtStep
+              c.Run::{
+              , name = "Test docs"
+              , run = "docs/makeSite"
+              , `if` = Some "startsWith(matrix.scala, '2.12')"
+              }
+          ]
 
 in  { name = "CI"
     , on = [ "push", "pull_request" ]
-    , jobs.build =
+    , jobs.build
+      =
             c.baseJob steps
         /\  { name = c.ciJobName "\${{ matrix.scala }}" "\${{ matrix.java }}"
             , strategy =

--- a/dhall/common.dhall
+++ b/dhall/common.dhall
@@ -25,59 +25,23 @@ let javaVersions = ./javaVersions.dhall
 let scalaVersions = ./scalaVersions.dhall
 
 let ciJobName =
-          \(scalaVersion : Text)
-      ->  \(javaVersion : Text)
-      ->  "Scala ${scalaVersion}, Java ${javaVersion}"
+      \(scalaVersion : Text) ->
+      \(javaVersion : Text) ->
+        "Scala ${scalaVersion}, Java ${javaVersion}"
 
 let steps =
-      let uses = \(uses : Text) -> BuildStep.Uses Uses::{ uses = uses }
+      let uses = \(uses : Text) -> BuildStep.Uses Uses::{ uses }
 
       in  { uses
           , checkout = uses "actions/checkout@v2"
           , java =
-                  \(version : Text)
-              ->  BuildStep.Uses
-                    Uses::{
-                    , uses = "actions/setup-java@v1"
-                    , `with` = Some (toMap { java-version = version })
-                    }
-          , cache =
-              let cacheConfig =
-                        \(config : { name : Text, path : Text, id : Text })
-                    ->  BuildStep.Uses
-                          Uses::{
-                          , name = Some config.name
-                          , uses = "actions/cache@v1"
-                          , `with` = Some
-                              ( toMap
-                                  { path = config.path
-                                  , key =
-                                      "${config.id}-\${{ env.current_week }}"
-                                  , restore-keys =
-                                      "${config.id}-\${{ env.last_week }}"
-                                  }
-                              )
-                          }
-
-              in  [ BuildStep.Run
-                      Run::{
-                      , name = "Get current week"
-                      , run =
-                          let currentWeek = "10#\$(date +%U)"
-
-                          in  ''
-                              echo "::set-env name=current_week::$(( ${currentWeek} ))"
-                              echo "::set-env name=last_week::$(( ${currentWeek} - 1 ))"
-                              ''
-                      }
-                  , cacheConfig
-                      { name = "Cache SBT coursier cache"
-                      , path = "~/.cache/coursier"
-                      , id = "coursier"
-                      }
-                  , cacheConfig
-                      { name = "Cache SBT", path = "~/.sbt", id = "sbt" }
-                  ]
+              \(version : Text) ->
+                BuildStep.Uses
+                  Uses::{
+                  , uses = "actions/setup-java@v1"
+                  , `with` = Some (toMap { java-version = version })
+                  }
+          , cache = uses "coursier/cache-action@v5"
           }
 
 in  { Uses

--- a/dhall/javaVersions.dhall
+++ b/dhall/javaVersions.dhall
@@ -1,1 +1,1 @@
-let default = "11" in { default, all = [ default, "14" ] }
+let default = "11" in { default, all = [ default, "15" ] }

--- a/dhall/mergify.dhall
+++ b/dhall/mergify.dhall
@@ -6,14 +6,14 @@ let ciJobNameRules =
       L.concatMap
         Text
         Text
-        (     \(scalaVersion : Text)
-          ->  L.map
-                Text
-                Text
-                (     \(javaVersion : Text)
-                  ->  "status-success=${c.ciJobName scalaVersion javaVersion}"
-                )
-                c.javaVersions.all
+        ( \(scalaVersion : Text) ->
+            L.map
+              Text
+              Text
+              ( \(javaVersion : Text) ->
+                  "status-success=${c.ciJobName scalaVersion javaVersion}"
+              )
+              c.javaVersions.all
         )
         c.scalaVersions.all
 

--- a/dhall/release.dhall
+++ b/dhall/release.dhall
@@ -1,39 +1,38 @@
 let c = ./common.dhall
 
 let steps =
-        [ c.steps.checkout
-        , c.BuildStep.Run
-            c.Run::{ name = "Unshallow", run = "git fetch --unshallow" }
-        , c.steps.java c.javaVersions.default
-        , c.steps.uses "olafurpg/setup-gpg@v2"
-        ]
-      # c.steps.cache
-      # [ c.BuildStep.Run
-            c.Run::{
-            , name = "Release"
-            , env = Some
-                ( toMap
-                    { PGP_SECRET = "\${{ secrets.PGP_SECRET }}"
-                    , PGP_PASSPHRASE = "\${{ secrets.PGP_PASSPHRASE }}"
-                    , SSH_PRIVATE_KEY = "\${{ secrets.SSH_PRIVATE_KEY }}"
-                    , SONATYPE_USERNAME = "\${{ secrets.SONATYPE_USERNAME }}"
-                    , SONATYPE_PASSWORD = "\${{ secrets.SONATYPE_PASSWORD }}"
-                    , SBT_GHPAGES_COMMIT_MESSAGE =
-                        "Updated site: sha=\${{ github.sha }} build=\${{ github.run_id }}"
-                    }
-                )
-            , run =
-                ''
-                echo "$PGP_SECRET" | base64 --decode | gpg --import --no-tty --batch --yes
-                eval "$(ssh-agent -s)"
-                echo "$SSH_PRIVATE_KEY" | ssh-add -
-                git config --global user.name "GitHub Actions CI"
-                git config --global user.email "ghactions@invalid"
+      [ c.steps.checkout
+      , c.BuildStep.Run
+          c.Run::{ name = "Unshallow", run = "git fetch --unshallow" }
+      , c.steps.java c.javaVersions.default
+      , c.steps.uses "olafurpg/setup-gpg@v2"
+      , c.steps.cache
+      , c.BuildStep.Run
+          c.Run::{
+          , name = "Release"
+          , env = Some
+              ( toMap
+                  { PGP_SECRET = "\${{ secrets.PGP_SECRET }}"
+                  , PGP_PASSPHRASE = "\${{ secrets.PGP_PASSPHRASE }}"
+                  , SSH_PRIVATE_KEY = "\${{ secrets.SSH_PRIVATE_KEY }}"
+                  , SONATYPE_USERNAME = "\${{ secrets.SONATYPE_USERNAME }}"
+                  , SONATYPE_PASSWORD = "\${{ secrets.SONATYPE_PASSWORD }}"
+                  , SBT_GHPAGES_COMMIT_MESSAGE =
+                      "Updated site: sha=\${{ github.sha }} build=\${{ github.run_id }}"
+                  }
+              )
+          , run =
+              ''
+              echo "$PGP_SECRET" | base64 --decode | gpg --import --no-tty --batch --yes
+              eval "$(ssh-agent -s)"
+              echo "$SSH_PRIVATE_KEY" | ssh-add -
+              git config --global user.name "GitHub Actions CI"
+              git config --global user.email "ghactions@invalid"
 
-                sbt ci-release docs/makeSite docs/ghpagesPushSite
-                ''
-            }
-        ]
+              sbt ci-release docs/makeSite docs/ghpagesPushSite
+              ''
+          }
+      ]
 
 in  { name = "Publish releases and snapshots"
     , on.push = { branches = [ "master" ], tags = [ "*" ] }


### PR DESCRIPTION
 - Use the excellent [coursier/cache-action](https://github.com/coursier/cache-action). Additionally, this fixes these [deprecation warnings](https://github.com/http4s/http4s-jdk-http-client/actions/runs/297494035).
 - Java 14 -> 15
 - Dependabot will update the version numbers for external GH actions (e.g. if a new major versionf or coursier/cache-action is released).

I also ran `dhall format` on all files for consistency.