### PR TITLE
Terminate CompletableFuture Values In All Exit States

### DIFF
--- a/core/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
+++ b/core/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
@@ -16,7 +16,6 @@ import fs2.interop.reactivestreams._
 import fs2.{Chunk, Stream}
 import org.http4s.client.Client
 import org.http4s.client.jdkhttpclient.compat.CollectionConverters._
-import org.http4s.internal.fromCompletionStage
 import org.http4s.util.CaseInsensitiveString
 import org.http4s.{Header, Headers, HttpVersion, Request, Response, Status}
 import org.reactivestreams.FlowAdapters
@@ -88,7 +87,9 @@ object JdkHttpClient {
       for {
         req <- Resource.liftF(convertRequest(req))
         res <- Resource.liftF(
-          fromCompletionStage(F.delay(jdkHttpClient.sendAsync(req, BodyHandlers.ofPublisher)))
+          fromCompletableFutureShift(
+            F.delay(jdkHttpClient.sendAsync(req, BodyHandlers.ofPublisher))
+          )
         )
         res <- convertResponse(res)
       } yield res

--- a/core/src/main/scala/org/http4s/client/jdkhttpclient/JdkWSClient.scala
+++ b/core/src/main/scala/org/http4s/client/jdkhttpclient/JdkWSClient.scala
@@ -16,7 +16,7 @@ import fs2.Chunk
 import fs2.concurrent.Queue
 import org.http4s.headers.`Sec-WebSocket-Protocol`
 import scodec.bits.ByteVector
-import org.http4s.internal.{fromCompletionStage, unsafeToCompletionStage}
+import org.http4s.internal.unsafeToCompletionStage
 
 /** A `WSClient` wrapper for the JDK 11+ websocket client.
   * It will reply to Pongs with Pings even in "low-level" mode.
@@ -79,7 +79,7 @@ object JdkWSClient {
                 handleReceive(error.asLeft); ()
               }
             }
-            webSocket <- fromCompletionStage(
+            webSocket <- fromCompletableFutureShift(
               F.delay(wsBuilder.buildAsync(URI.create(uri.renderString), wsListener))
             )
             sendSem <- Semaphore[F](1L)
@@ -87,7 +87,7 @@ object JdkWSClient {
         } { case (webSocket, queue, _) =>
           for {
             isOutputOpen <- F.delay(!webSocket.isOutputClosed)
-            closeOutput = fromCompletionStage(
+            closeOutput = fromCompletableFutureShift(
               F.delay(webSocket.sendClose(JWebSocket.NORMAL_CLOSURE, ""))
             )
             _ <-
@@ -111,7 +111,7 @@ object JdkWSClient {
         .map { case (webSocket, queue, sendSem) =>
           // sending will throw if done in parallel
           val rawSend = (wsf: WSFrame) =>
-            fromCompletionStage(F.delay(wsf match {
+            fromCompletableFutureShift(F.delay(wsf match {
               case WSFrame.Text(text, last) => webSocket.sendText(text, last)
               case WSFrame.Binary(data, last) => webSocket.sendBinary(data.toByteBuffer, last)
               case WSFrame.Ping(data) => webSocket.sendPing(data.toByteBuffer)

--- a/core/src/main/scala/org/http4s/client/jdkhttpclient/package.scala
+++ b/core/src/main/scala/org/http4s/client/jdkhttpclient/package.scala
@@ -1,0 +1,45 @@
+package org.http4s.client
+
+import cats.effect._
+import cats.effect.syntax.all._
+import cats.syntax.all._
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+
+package object jdkhttpclient {
+
+  /** Convert a [[java.util.concurrent.CompletableFuture]] into an effect type.
+    *
+    * If the effect type terminates in cancellation or error, the underlying
+    * [[java.util.concurrent.CompletableFuture]] is terminated in an analogous
+    * manner. This is important, otherwise a resource leak may occur.
+    *
+    * @note Finally, regardless of how the effect and
+    *       [[java.util.concurrent.CompletableFuture]] complete, the result is
+    *       shifted with the given [[cats.effect.ContextShift]].
+    */
+  private[jdkhttpclient] def fromCompletableFutureShift[F[_], A](
+      fcs: F[CompletableFuture[A]]
+  )(implicit F: Concurrent[F], CS: ContextShift[F]): F[A] =
+    F.bracketCase(fcs) { cs =>
+      F.async[A] { cb =>
+        cs.handle[Unit] { (result, err) =>
+          err match {
+            case null => cb(Right(result))
+            case _: CancellationException => ()
+            case ex: CompletionException if ex.getCause ne null => cb(Left(ex.getCause))
+            case ex => cb(Left(ex))
+          }
+        }; ();
+      }
+    }((cs, ec) =>
+      (ec match {
+        case ExitCase.Completed => F.unit
+        case ExitCase.Error(e) =>
+          F.delay(cs.completeExceptionally(e))
+        case ExitCase.Canceled =>
+          F.delay(cs.cancel(true))
+      }).void.guarantee(CS.shift)
+    )
+}

--- a/core/src/test/scala/org/http4s/client/jdkhttpclient/CompletableFutureTerminationTest.scala
+++ b/core/src/test/scala/org/http4s/client/jdkhttpclient/CompletableFutureTerminationTest.scala
@@ -78,7 +78,7 @@ final class CompletableFutureTerminationTest extends Specification with CatsIO {
                     // Wait until we are sure the Http4s Server has received the
                     // request.
                     gotRequest.acquire *>
-                      // Lift the CompletableFuture to a IO value and attache a
+                      // Lift the CompletableFuture to a IO value and attach a
                       // (short) timeout to the termination.
                       //
                       // Important! The IO result _must_ be terminated via the

--- a/core/src/test/scala/org/http4s/client/jdkhttpclient/CompletableFutureTerminationTest.scala
+++ b/core/src/test/scala/org/http4s/client/jdkhttpclient/CompletableFutureTerminationTest.scala
@@ -88,14 +88,18 @@ final class CompletableFutureTerminationTest extends Specification with CatsIO {
                       // complete_ and we are in a different context.
                       //
                       // Notice that we release stallServer _after_ the
-                      // timeout. _This is the crux of this entire test_. Once we
-                      // release `stallServer`, the Http4s Server will attempt to
-                      // send back an Http Response to our JDK client. If the
-                      // CompletableFuture and associated resources were properly
-                      // cleaned up after the timeoutTo terminated the running
-                      // effect, then the JDK client connection will be closed. If
-                      // not, then it will still receive bytes, meaning there is a
-                      // resource leak.
+                      // timeout. _This is the crux of this entire test_. Once
+                      // we release `stallServer`, the Http4s Server will
+                      // attempt to send back an Http Response to our JDK
+                      // client. If the CompletableFuture and associated
+                      // resources were properly cleaned up after the
+                      // timeoutTo terminated the running effect, then the JDK
+                      // client connection will either be closed, or the
+                      // attempt to invoke `complete` on the
+                      // `CompletableFuture` will fail, in both cases
+                      // releasing any resources being held. If not, then it
+                      // will still receive bytes, meaning there is a resource
+                      // leak.
                       fromCompletableFutureShift(IO(cf)).void
                         .timeoutTo(duration, stallServer.release) *>
                       // After the timeout has triggered, wait for the observation to complete.

--- a/core/src/test/scala/org/http4s/client/jdkhttpclient/CompletableFutureTerminationTest.scala
+++ b/core/src/test/scala/org/http4s/client/jdkhttpclient/CompletableFutureTerminationTest.scala
@@ -1,0 +1,207 @@
+package org.http4s.client.jdkhttpclient
+
+import cats.syntax.all._
+import cats.effect._
+import cats.effect.concurrent._
+import java.util.concurrent.TimeUnit
+import scala.concurrent._
+import scala.concurrent.duration._
+import org.http4s._
+import org.http4s.server._
+import org.http4s.server.blaze._
+import cats.data._
+import cats.effect.testing.specs2.CatsIO
+import org.specs2.mutable.Specification
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.util.concurrent.CompletableFuture
+
+final class CompletableFutureTerminationTest extends Specification with CatsIO {
+  import CompletableFutureTerminationTest._
+
+  private val duration: FiniteDuration =
+    FiniteDuration(50L, TimeUnit.MILLISECONDS)
+
+  // This test ensures that converting from a
+  // java.util.concurrent.CompletableFuture to an effect type, such as IO,
+  // will properly terminate the CompletableFuture if the resulting effect is
+  // terminated externally, e.g. with a timeout.
+  //
+  // This is _really_ important, because the JDK HttpClient may buffer
+  // resources and/or continue execution if external termination events don't
+  // cancel/completeExceptionally the CompletableFuture. In the best case this
+  // would yield unnecessary CPU cycles, and in the worst it is a memory leak.
+  //
+  // This is _not_ an issue with the fs2 Reactive streams implementation. That
+  // implementation _will_ terminate the result if `onError` or `onComplete`
+  // is invoked or if the `fs2.Stream` value terminates in error. The issue is
+  // that if the outer effect fails _before_ any data has started to be
+  // processed in the CompletableFuture, then no cancellation or exception is
+  // sent to the fs2 reactive streams wrapper. This causes a small amount of
+  // data to be buffered, waiting to be read, but it will never be read.
+  //
+  // There is a not about this in the JavaDocs. The Response of a HttpClient
+  // must be drained via an `onError` or `onComplete` observed by the response
+  // body handler or a cancellation via the CompletableFuture.
+  //
+  // See: https://docs.oracle.com/en/java/javase/14/docs/api/java.net.http/java/net/http/HttpResponse.BodySubscriber.html
+  "Terminating an effect generated from a CompletableFuture" should {
+    "terminate the execution of the CompletableFuture" in {
+      (Semaphore[IO](1L), Deferred[IO, Observation[HttpResponse[String]]], Semaphore[IO](1L)).tupled
+        .flatMap { case (stallServer, observation, gotRequest) =>
+          // Acquire the `stallServer` semaphore so that the server will not
+          // return _any_ bytes until we release a permit.
+          stallServer.acquire *>
+            // Acquire the `gotRequest` semaphore. The server will release this
+            // once it gets our Request. We wait until this happens to start our
+            // timeout logic.
+            gotRequest.acquire *>
+            // Start a Http4s Server, it will be terminated at the conclusion of
+            // this test.
+            stallingServerR[IO](stallServer, gotRequest, super.executionContext).use {
+              (server: Server[IO]) =>
+                // Call the server, using the JDK client. We call directly with
+                // the JDK client because we need to have low level control over
+                // the result to observe whether or not the
+                // java.util.concurrent.CompletableFuture is still executing (and
+                // holding on to resources).
+                callServer[IO](server).flatMap((cf: CompletableFuture[HttpResponse[String]]) =>
+                  // Attach a handler onto the result. This will populate our
+                  // `observation` Deferred value when the CompletableFuture
+                  // finishes for any reason.
+                  //
+                  // We start executing this in the background, so that we
+                  // asynchronously populate our Observation.
+                  observeCompletableFuture(observation, cf).start.flatMap(fiber =>
+                    // Wait until we are sure the Http4s Server has received the
+                    // request.
+                    gotRequest.acquire *>
+                      // Lift the CompletableFuture to a IO value and attache a
+                      // (short) timeout to the termination.
+                      //
+                      // Important! The IO result _must_ be terminated via the
+                      // timeout _before any bytes_ have been received by the JDK
+                      // HttpClient in order to validate resource safety. Once we
+                      // start getting bytes back, the CompletableFuture _is
+                      // complete_ and we are in a different context.
+                      //
+                      // Notice that we release stallServer _after_ the
+                      // timeout. _This is the crux of this entire test_. Once we
+                      // release `stallServer`, the Http4s Server will attempt to
+                      // send back an Http Response to our JDK client. If the
+                      // CompletableFuture and associated resources were properly
+                      // cleaned up after the timeoutTo terminated the running
+                      // effect, then the JDK client connection will be closed. If
+                      // not, then it will still receive bytes, meaning there is a
+                      // resource leak.
+                      fromCompletableFutureShift(IO(cf)).void
+                        .timeoutTo(duration, stallServer.release) *>
+                      // After the timeout has triggered, wait for the observation to complete.
+                      fiber.join *>
+                      // Check our observation. Whether or not there is an exception
+                      // is not actually relevant to the success case. What _is_
+                      // important is that there is no result. If there is a result,
+                      // then that means that _after_ `timeoutTo` released
+                      // `stallServer` the CompletableFuture for the Http response
+                      // body still processed data, which indicates a resource leak.
+                      observation.get.flatMap {
+                        case Observation(None, _) => IO.pure(true)
+                        case otherwise =>
+                          IO.raiseError(new AssertionError(s"Expected no result, got $otherwise"))
+                      }
+                  )
+                )
+            }
+        }
+    }
+  }
+}
+
+object CompletableFutureTerminationTest {
+
+  /** ADT to contain the result of an invocation to
+    * [[java.util.concurrent.CompletionStage#handleAsync]]
+    */
+  private final case class Observation[A](
+      result: Option[A],
+      t: Option[Throwable]
+  )
+
+  /** A resource which provides a Http4s Server, which can stall the generation
+    * of a http response until signaled by test code.
+    *
+    * This provides the ability to prevent the server from returning a
+    * response until a permit is released. It is meant to only process one
+    * test request.
+    *
+    * @param semaphore A permit will be acquired and released form this for
+    *        each request. Drain it before sending a request to the server and
+    *        then release a permit when you want to server to process the
+    *        request.
+    * @param gotRequest A permit will be released into this semaphore each
+    *        time a request is received. After sending a request to this
+    *        server, you can acquire a permit from this semaphore in your test
+    *        code to ensure the server has received the request. This permit
+    *        is acquired ''before'' one is acquired from `semaphore`.
+    */
+  private def stallingServerR[F[_]](
+      semaphore: Semaphore[F],
+      gotRequest: Semaphore[F],
+      ec: ExecutionContext
+  )(implicit F: ConcurrentEffect[F], T: Timer[F]): Resource[F, Server[F]] =
+    BlazeServerBuilder(ec)
+      .withHttpApp(
+        Kleisli(
+          Function.const(
+            gotRequest.release *>
+              semaphore.withPermit(
+                F.pure(Response[F]())
+              )
+          )
+        )
+      )
+      .bindAny()
+      .resource
+
+  /** Just a scala wrapper class to make it easier to generate a
+    * [[java.util.funciton.BiFunction]].
+    */
+  private final case class JBiFunction[A, B, C](f: A => B => C)
+      extends java.util.function.BiFunction[A, B, C] {
+    override def apply(a: A, b: B): C =
+      f(a)(b)
+  }
+
+  /** Given a [[cats.effect.concurrent.Deferred]] value and a
+    * [[java.util.concurrent.CompletableFuture]] value, attach a handler to
+    * the `CompletableFuture` which reports an [[Observation]] of the result
+    * in all cases (success/cancellation/failure).
+    */
+  private def observeCompletableFuture[F[_], A](
+      observe: Deferred[F, Observation[A]],
+      cf: CompletableFuture[A]
+  )(implicit F: Async[F]): F[Unit] =
+    F.async { (cb: Either[Throwable, Observation[A]] => Unit) =>
+      cf.handleAsync[Unit](
+        JBiFunction[A, Throwable, Unit](result =>
+          t => cb(Right(Observation(Option(result), Option(t))))
+        )
+      ); ();
+    }.flatMap(observe.complete)
+
+  /** Given a Http4s Server, make a GET request to `/` using a JDK HttpClient
+    * and return the result in a [[java.util.concurrent.CompletableFuture]].
+    */
+  private def callServer[F[_]](
+      server: Server[F]
+  )(implicit F: Sync[F]): F[CompletableFuture[HttpResponse[String]]] =
+    for {
+      jURI <- F.catchNonFatal(new URI(server.baseUri.renderString))
+      client <- F.delay(HttpClient.newHttpClient)
+      result <- F.delay(
+        client.sendAsync(HttpRequest.newBuilder(jURI).build(), HttpResponse.BodyHandlers.ofString)
+      )
+    } yield result
+}

--- a/core/src/test/scala/org/http4s/client/jdkhttpclient/CompletableFutureTerminationTest.scala
+++ b/core/src/test/scala/org/http4s/client/jdkhttpclient/CompletableFutureTerminationTest.scala
@@ -127,6 +127,13 @@ object CompletableFutureTerminationTest {
 
   /** ADT to contain the result of an invocation to
     * [[java.util.concurrent.CompletionStage#handleAsync]]
+    *
+    * @note [[scala.Option]] is used because either or both of these values
+    *       may be `null` in the JRE API.
+    *
+    * @note This is ''not'' a disjunction, e.g. [[scala.Either]]. The JRE API
+    *       dictates that both values might be non-null and both values might
+    *       be `null`.
     */
   private final case class Observation[A](
       result: Option[A],
@@ -170,7 +177,7 @@ object CompletableFutureTerminationTest {
       .resource
 
   /** Just a scala wrapper class to make it easier to generate a
-    * [[java.util.funciton.BiFunction]].
+    * [[java.util.function.BiFunction]].
     */
   private final case class JBiFunction[A, B, C](f: A => B => C)
       extends java.util.function.BiFunction[A, B, C] {

--- a/core/src/test/scala/org/http4s/client/jdkhttpclient/CompletableFutureTerminationTest.scala
+++ b/core/src/test/scala/org/http4s/client/jdkhttpclient/CompletableFutureTerminationTest.scala
@@ -42,7 +42,7 @@ final class CompletableFutureTerminationTest extends Specification with CatsIO {
   // sent to the fs2 reactive streams wrapper. This causes a small amount of
   // data to be buffered, waiting to be read, but it will never be read.
   //
-  // There is a not about this in the JavaDocs. The Response of a HttpClient
+  // There is a note about this in the JavaDocs. The Response of a HttpClient
   // must be drained via an `onError` or `onComplete` observed by the response
   // body handler or a cancellation via the CompletableFuture.
   //


### PR DESCRIPTION
This commit adds a new function `fromCompletableFutureShift` and replaces the usage of `fromCompletionStage` with this function.

This function is similar to `fromCompletionStage`, except that it brackets on the effect, ensuring that in the case of cancellation or error the `CompletableFuture` is terminated with `.cancel` or `.completeExceptionally`.

Failing to do this, as `fromCompletionStage` did, can lead to a resource leak and extra CPU cycles when the effect which results from `fromCompletionStage` is terminated due to some external condition, e.g. `.timeout`.

To verify this, one needs only replace `fromCompletableFutureShift` in `CompletableFutureTerminationTest` with `org.http4s.internal.fromCompletionStage` and run the test.