### PR TITLE
Fix Resource Leak When The HTTPResponse Body Is Not Read

### DIFF
--- a/core/src/main/scala/org/http4s/client/jdkhttpclient/AlwaysCancelingSubscriber.scala
+++ b/core/src/main/scala/org/http4s/client/jdkhttpclient/AlwaysCancelingSubscriber.scala
@@ -9,15 +9,11 @@ import java.util.concurrent.Flow
   * cases where the HTTP body is not read.
   */
 private[jdkhttpclient] final class AlwaysCancelingSubscriber[A] extends Flow.Subscriber[A] {
-  override def onSubscribe(subscription: Flow.Subscription): Unit =
-    subscription.cancel
+  override def onSubscribe(subscription: Flow.Subscription): Unit = subscription.cancel
 
-  override def onComplete(): Unit =
-    ()
+  override val onComplete: Unit = ()
 
-  override def onError(throwable: Throwable): Unit =
-    throw throwable
+  override def onError(throwable: Throwable): Unit = throw throwable
 
-  override def onNext(item: A): Unit =
-    ()
+  override def onNext(item: A): Unit = ()
 }

--- a/core/src/main/scala/org/http4s/client/jdkhttpclient/AlwaysCancelingSubscriber.scala
+++ b/core/src/main/scala/org/http4s/client/jdkhttpclient/AlwaysCancelingSubscriber.scala
@@ -1,0 +1,30 @@
+package org.http4s.client.jdkhttpclient
+
+import java.util.concurrent.Flow
+
+/** An implementation of a JRE `Flow.Subscriber` which immediately cancels the
+  * `Flow.Subscription`.
+  *
+  * We use this to clean up resources and conform the JRE API contract in
+  * cases where the HTTP body is not read.
+  */
+private[jdkhttpclient] final class AlwaysCancelingSubscriber[A] extends Flow.Subscriber[A] {
+  override def onSubscribe(subscription: Flow.Subscription): Unit =
+    subscription.cancel
+
+  override def onComplete(): Unit =
+    throw new IllegalStateException(
+      "AlwaysCancelingSubscriber onComplete was invoked. This should never occur as only onSubscribe should be called."
+    )
+
+  override def onError(throwable: Throwable): Unit =
+    throw new IllegalStateException(
+      "AlwaysCancelingSubscriber onError was invoked. This should never occur as only onSubscribe should be called.",
+      throwable
+    )
+
+  override def onNext(item: A): Unit =
+    throw new IllegalStateException(
+      "AlwaysCancelingSubscriber onNext was invoked. This should never occur as only onSubscribe should be called."
+    )
+}

--- a/core/src/main/scala/org/http4s/client/jdkhttpclient/AlwaysCancelingSubscriber.scala
+++ b/core/src/main/scala/org/http4s/client/jdkhttpclient/AlwaysCancelingSubscriber.scala
@@ -13,18 +13,11 @@ private[jdkhttpclient] final class AlwaysCancelingSubscriber[A] extends Flow.Sub
     subscription.cancel
 
   override def onComplete(): Unit =
-    throw new IllegalStateException(
-      "AlwaysCancelingSubscriber onComplete was invoked. This should never occur as only onSubscribe should be called."
-    )
+    ()
 
   override def onError(throwable: Throwable): Unit =
-    throw new IllegalStateException(
-      "AlwaysCancelingSubscriber onError was invoked. This should never occur as only onSubscribe should be called.",
-      throwable
-    )
+    throw throwable
 
   override def onNext(item: A): Unit =
-    throw new IllegalStateException(
-      "AlwaysCancelingSubscriber onNext was invoked. This should never occur as only onSubscribe should be called."
-    )
+    ()
 }

--- a/core/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
+++ b/core/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
@@ -89,7 +89,7 @@ object JdkHttpClient {
     // intentionally _do not_ subscribe to the publisher until the first
     // attempt to pull from the Stream.
     //
-    // https://github.com/typelevel/fs2/blob//reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscriber.scala#L64
+    // https://github.com/typelevel/fs2/blob/v2.5.0/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscriber.scala#L64
     //
     // In the general case, this is fine and probably even ideal. After all if
     // you are never going to pull from a Stream, why do all the booking setup
@@ -114,7 +114,7 @@ object JdkHttpClient {
     // Semaphore (it will never be released). The code for this is similar to
     // the body of the fromPublisher method in fs2.
     //
-    // https://github.com/typelevel/fs2/blob//reactive-streams/src/main/scala/fs2/interop/reactivestreams/package.scala#L55
+    // https://github.com/typelevel/fs2/blob/v2.5.0/reactive-streams/src/main/scala/fs2/interop/reactivestreams/package.scala#L55
     //
     // In the release section of bracket on the response, we also attempt to
     // acquire the single permit from the Semaphore. If we are successfully

--- a/core/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
+++ b/core/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
@@ -92,8 +92,7 @@ object JdkHttpClient {
     // https://github.com/typelevel/fs2/blob/v2.5.0/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscriber.scala#L64
     //
     // In the general case, this is fine and probably even ideal. After all if
-    // you are never going to pull from a Stream, why do all the booking setup
-    // work?
+    // you are never going to pull from a Stream, why do all the setup work?
     //
     // Unfortunately, the reactive streams semantics for the JDK client are
     // not the "general case". In order to not leak resources, there _must_ be

--- a/core/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
+++ b/core/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
@@ -120,8 +120,8 @@ object JdkHttpClient {
     // that Publisher was never subscribed to, either due to an error or more
     // likely because the calling code didn't care about the body of the
     // request. In this case we subscribe to the body and then immediately
-    // cancel the subscription, freeing the resources.
-    // If the TryableDeferred has not been completed, we do nothing.
+    // cancel the subscription, freeing the resources.  If the TryableDeferred
+    // has already been completed, we do nothing.
     //
     // There are a couple items worth giving special attention to here.
     //

--- a/core/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
+++ b/core/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
@@ -10,6 +10,7 @@ import java.util.concurrent.Flow
 
 import cats.ApplicativeError
 import cats.effect._
+import cats.effect.concurrent._
 import cats.implicits._
 import fs2.concurrent.SignallingRef
 import fs2.interop.reactivestreams._
@@ -58,38 +59,167 @@ object JdkHttpClient {
         (if (headers.isEmpty) rb else rb.headers(headers: _*)).build
       }
 
-    def convertResponse(
-        res: HttpResponse[Flow.Publisher[util.List[ByteBuffer]]]
+    // Convert the JDK HttpResponse into a http4s Response value.
+    //
+    // Aside form converting between the JDK types and the http4s types, this
+    // function also ensures that the body of the response is properly
+    // handled.
+    //
+    // From the JDK docs for HttpResponse#BodyHandlers.ofPublisher,
+    // https://docs.oracle.com/en/java/javase/15/docs/api/java.net.http/java/net/http/HttpResponse.BodyHandlers.html#ofPublisher()
+    //
+    // > When the HttpResponse object is returned, the response headers will
+    // > have been completely read, but the body may not have been fully
+    // > received yet. The HttpResponse.body() method returns a
+    // > Publisher<List<ByteBuffer>> from which the body response bytes can be
+    // > obtained as they are received. The publisher can and must be subscribed
+    // > to only once.
+    //
+    // Of particular note is the final sentence, "The publisher can and must
+    // be subscribed to only once.".
+    //
+    // This poses a bit of a problem for us in the cases where the body is not
+    // inspected, e.g. org.http4s.client.Client#status or any function which
+    // doesn't inspect the response body in
+    // org.http4s.client.Client#run. Functions such as these will never
+    // attempt to pull from the fs2.Stream, and it will just silently leave
+    // scope and in doing so never subscribe to the JDK HttpResponse body
+    // Publisher.  This is because functions provided by fs2 for converting a
+    // reactive streams publisher into a fs2.Stream explicitly and
+    // intentionally _do not_ subscribe to the publisher until the first
+    // attempt to pull from the Stream.
+    //
+    // https://github.com/typelevel/fs2/blob//reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscriber.scala#L64
+    //
+    // In the general case, this is fine and probably even ideal. After all if
+    // you are never going to pull from a Stream, why do all the booking setup
+    // work?
+    //
+    // Unfortunately, the reactive streams semantics for the JDK client are
+    // not the "general case". In order to not leak resources, there _must_ be
+    // _exactly one_ subscription to the body publisher _and_ it must either
+    // be read until it is exhausted or `.cancel` _must_ be invoked.
+    //
+    // Making matters more complicated, fs2's implementation does not provide
+    // any way to directly invoke this type of operation, e.g. subscribe and
+    // then immediately cancel.
+    //
+    // Thus, in order to solve this problem and satisfy the JDK HttpResponse's
+    // API so as to not leak resources, we do the following.
+    //
+    // We create a single permit Semaphore and bracket its creation as well as
+    // the invocation of the effect which yields the JDK HttpResponse. Using
+    // the lower level fs2 reactive streams APIs, we ensure the attempt to
+    // subscribe to the Publisher first drains the single permit from the
+    // Semaphore (it will never be released). The code for this is similar to
+    // the body of the fromPublisher method in fs2.
+    //
+    // https://github.com/typelevel/fs2/blob//reactive-streams/src/main/scala/fs2/interop/reactivestreams/package.scala#L55
+    //
+    // In the release section of bracket on the response, we also attempt to
+    // acquire the single permit from the Semaphore. If we are successfully
+    // able to do so, that means that Publisher was never subscribed to,
+    // either due to an error or more likely because the calling code didn't
+    // care about the body of the request. In this case we subscribe to the
+    // body and then immediately cancel the subscription, freeing the
+    // resources. If the Semaphore has already been drained, we do nothing.
+    //
+    // There are a couple items worth giving special attention to here.
+    //
+    // * It is important that we attach the finalizer which can run
+    // AlwaysCancelingSubscriber as soon as we run the effect to trigger the
+    // response. We _could_ attach it later, e.g. when we attach the body
+    // interruption signal, but this happens after a number of other side
+    // effects are run. If anything triggers abnormal termination _after_ we
+    // have the HttpResponse, but _before_ we've attached this finalizer, then
+    // we will have a resource leak.
+    //
+    // * Interrupting the response body stream alone will not trigger
+    // subscription and cancellation. Subscription only happens after someone
+    // attempts to pull from the Stream, which doesn't happen in cases where
+    // the body is discarded. Interrupting the fs2.Stream with a second
+    // Resource is still required to cleanup the fs2.Stream scopes, whether or
+    // not the Publisher was ever subscribed to.
+    def convertResponse[A](
+        responseF: F[HttpResponse[Flow.Publisher[util.List[ByteBuffer]]]]
     ): Resource[F, Response[F]] =
-      Resource(
-        (F.fromEither(Status.fromInt(res.statusCode)), SignallingRef[F, Boolean](false)).mapN {
-          case (status, signal) =>
-            Response(
-              status = status,
-              headers = Headers(res.headers.map.asScala.flatMap { case (k, vs) =>
-                vs.asScala.map(Header(k, _))
-              }.toList),
-              httpVersion = res.version match {
-                case HttpClient.Version.HTTP_1_1 => HttpVersion.`HTTP/1.1`
-                case HttpClient.Version.HTTP_2 => HttpVersion.`HTTP/2.0`
-              },
-              body = FlowAdapters
-                .toPublisher(res.body)
-                .toStream[F]
-                .interruptWhen(signal)
-                .flatMap(bs => Stream.fromIterator(bs.iterator.asScala.map(Chunk.byteBuffer)))
-                .flatMap(Stream.chunk)
-            ) -> signal.set(true)
+      Resource
+        .make(
+          (Semaphore[F](1L), responseF).tupled
+        ) { case (semaphore, response) =>
+          semaphore.tryAcquire.flatMap {
+            case true =>
+              // Indicates response was never subscribed to. In this case, in
+              // order to conform to the API contract from the
+              // HttpResponse.BodyHandlers.ofPublisher, we must subscribe to
+              // the body and then immediately cancel the subscription (or
+              // read the entire body). If we do not do this we will have a
+              // resource leak.
+              //
+              // This is actually a pretty common case. Any HTTP response for
+              // which the caller doesn't care about the body,
+              // e.g. Client#status, will trigger this case.
+              F.delay(
+                response.body.subscribe(new AlwaysCancelingSubscriber)
+              )
+            case _ =>
+              F.unit
+          }
         }
-      )
+        .flatMap { case (semaphore, res) =>
+          val body: Stream[F, util.List[ByteBuffer]] =
+            Stream
+              .eval(
+                StreamSubscriber[F, util.List[ByteBuffer]]
+              )
+              .flatMap(s =>
+                s.sub.stream(
+                  // Drain the single permit from the Semaphore so that we
+                  // indicate we have subscribed to the Publisher.
+                  //
+                  // This only happens _after_ someone attempts to pull from the
+                  // body and will never happen if the body is never pulled
+                  // from. In that case, the AlwaysCancelingSubscriber handles
+                  // cleanup.
+                  semaphore.tryAcquire.flatMap {
+                    case true =>
+                      F.delay(FlowAdapters.toPublisher(res.body).subscribe(s))
+                    case _ =>
+                      // Should never occur.
+                      F.raiseError(
+                        new IllegalStateException(
+                          "Attempt to subscribe to response body which had already been subscribed too. This likely indicates a bug in the http4s JDK client."
+                        )
+                      )
+                  }
+                )
+              )
+          Resource(
+            (F.fromEither(Status.fromInt(res.statusCode)), SignallingRef[F, Boolean](false)).mapN {
+              case (status, signal) =>
+                Response(
+                  status = status,
+                  headers = Headers(res.headers.map.asScala.flatMap { case (k, vs) =>
+                    vs.asScala.map(Header(k, _))
+                  }.toList),
+                  httpVersion = res.version match {
+                    case HttpClient.Version.HTTP_1_1 => HttpVersion.`HTTP/1.1`
+                    case HttpClient.Version.HTTP_2 => HttpVersion.`HTTP/2.0`
+                  },
+                  body = body
+                    .interruptWhen(signal)
+                    .flatMap(bs => Stream.fromIterator(bs.iterator.asScala.map(Chunk.byteBuffer)))
+                    .flatMap(Stream.chunk)
+                ) -> signal.set(true)
+            }
+          )
+        }
 
     Client[F] { req =>
       for {
         req <- Resource.liftF(convertRequest(req))
-        res <- Resource.liftF(
-          fromCompletableFutureShift(
-            F.delay(jdkHttpClient.sendAsync(req, BodyHandlers.ofPublisher))
-          )
+        res = fromCompletableFutureShift(
+          F.delay(jdkHttpClient.sendAsync(req, BodyHandlers.ofPublisher))
         )
         res <- convertResponse(res)
       } yield res

--- a/core/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
+++ b/core/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
@@ -140,7 +140,7 @@ object JdkHttpClient {
     // the body is discarded. Interrupting the fs2.Stream with a second
     // Resource is still required to cleanup the fs2.Stream scopes, whether or
     // not the Publisher was ever subscribed to.
-    def convertResponse[A](
+    def convertResponse(
         responseF: F[HttpResponse[Flow.Publisher[util.List[ByteBuffer]]]]
     ): Resource[F, Response[F]] =
       Resource

--- a/core/src/test/scala/org/http4s/client/jdkhttpclient/BodyLeakExample.scala
+++ b/core/src/test/scala/org/http4s/client/jdkhttpclient/BodyLeakExample.scala
@@ -6,8 +6,8 @@ import cats.effect.concurrent._
 import cats.syntax.all._
 import org.http4s._
 import org.http4s.client._
-import org.http4s.syntax.all._
 import org.http4s.server.blaze.BlazeServerBuilder
+import org.http4s.syntax.all._
 
 // This is a *manual* test for the body leak fixed in #335
 // Run e.g. with `bloop run core-test --args -J-Xmx200M`

--- a/core/src/test/scala/org/http4s/client/jdkhttpclient/BodyLeakExample.scala
+++ b/core/src/test/scala/org/http4s/client/jdkhttpclient/BodyLeakExample.scala
@@ -1,10 +1,11 @@
+package org.http4s.client.jdkhttpclient
+
 import cats.data._
 import cats.effect._
 import cats.effect.concurrent._
 import cats.syntax.all._
 import org.http4s._
 import org.http4s.client._
-import org.http4s.client.jdkhttpclient._
 import org.http4s.syntax.all._
 import org.http4s.server.blaze.BlazeServerBuilder
 

--- a/core/src/test/scala/org/http4s/client/jdkhttpclient/BodyLeakExample.scala
+++ b/core/src/test/scala/org/http4s/client/jdkhttpclient/BodyLeakExample.scala
@@ -1,0 +1,44 @@
+import cats.data._
+import cats.effect._
+import cats.effect.concurrent._
+import cats.syntax.all._
+import org.http4s._
+import org.http4s.client._
+import org.http4s.client.jdkhttpclient._
+import org.http4s.syntax.all._
+import org.http4s.server.blaze.BlazeServerBuilder
+
+// This is a *manual* test for the body leak fixed in #335
+// Run e.g. with `bloop run core-test --args -J-Xmx200M`
+object BodyLeakExample extends IOApp {
+
+  val app: HttpApp[IO] =
+    Kleisli((_: Request[IO]) => IO.pure(Response[IO]().withEntity("Hello, HTTP")))
+
+  def runRequest(client: Client[IO], counter: Ref[IO, Long]): IO[Unit] =
+    client.status(
+      Request[IO](method = Method.GET, uri = uri"http://127.0.0.1:8080")
+    ) *> counter
+      .updateAndGet(_ + 1L)
+      .flatMap(value =>
+        if (value % 1000L === 0L) {
+          IO(println(s"Request count: ${value}"))
+        } else {
+          IO.unit
+        }
+      )
+
+  override def run(args: List[String]): IO[ExitCode] =
+    BlazeServerBuilder[IO](executionContext)
+      .bindLocal(8080)
+      .withHttpApp(app)
+      .resource
+      .use { _ =>
+        for {
+          client <- JdkHttpClient.simple[IO]
+          counter <- Ref.of[IO, Long](0L)
+          ec <- runRequest(client, counter).foreverM[ExitCode]
+        } yield ec
+      }
+
+}


### PR DESCRIPTION
From the JDK docs for HttpResponse#BodyHandlers.ofPublisher,

https://docs.oracle.com/en/java/javase/15/docs/api/java.net.http/java/net/http/HttpResponse.BodyHandlers.html#ofPublisher()

> When the HttpResponse object is returned, the response headers will have been completely read, but the body may not have been fully received yet. The HttpResponse.body() method returns a Publisher<List<ByteBuffer>> from which the body response bytes can be obtained as they are received. The publisher can and must be subscribed to only once.

Of particular note is the final sentence, "The publisher can and must be subscribed to only once.".

There is a much longer discussion on the semantics of this in the comments in the code, but the short version is that we must always ensure that the `Flow.Publisher` returned on the `HttpResponse` when we use `BodyHandlers.ofPublisher` is subscribed to _exactly once_, whether or not anyone reads the body. Once we subscribe, the `Flow.Subscription` must be read or canceled.

Prior to this commit, we weren't doing that in cases where the body was not read, e.g. `Client#status`. For clarification, we _were_ (and still are) interrupting the body stream via a `.interruptWhen` call, but this doesn't subscribe to the `Producer` if no one has attempted to pull from the `fs2.Stream` yet.

It is _really hard_ to write a unit test to demonstrate this behavior, but thankfully, it is _really easy_ to write some toy code which triggers it. To that end, see https://github.com/isomarcte/http4s-jdk-client-body-resource-leak , which is a repo which has a POC of this error. Running the `Main` method in there should trigger the issue in about 15 seconds. If you locally publish this commit and then re-run that with the new version, it will run forever using constant memory as intended.

For convenience, here are links to the relevant documentation or code,

* https://docs.oracle.com/en/java/javase/15/docs/api/java.net.http/java/net/http/HttpResponse.BodyHandlers.html#ofPublisher()
* https://github.com/typelevel/fs2/blob/v2.5.0/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscriber.scala#L64
    * Note about how fs2 doesn't subscribe until someone starts pulling from the Stream.
* https://github.com/typelevel/fs2/blob/v2.5.0/reactive-streams/src/main/scala/fs2/interop/reactivestreams/package.scala#L55
    * Shows how to make a fs2.Stream from a Publisher and attach an effect to the subscription event. This commit uses this to ensure that subscription always happens exactly once.