### PR TITLE
disable snapshot publishing for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,7 @@ inThisBuild(
       )
     ),
     githubWorkflowPublishTargetBranches := Seq(
-      RefPredicate.Equals(Ref.Branch("main")),
+      // RefPredicate.Equals(Ref.Branch("main")),
       RefPredicate.StartsWith(Ref.Tag("v"))
     )
   )


### PR DESCRIPTION
see djspiewak/sbt-spiewak#44

In particular, snapshots are not released as such, but rather as "normal" releases, see https://search.maven.org/artifact/org.http4s/http4s-jdk-http-client_2.12/0.3-4-1910a08/jar