### PR TITLE
reenable snapshot publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/build.sbt
+++ b/build.sbt
@@ -103,6 +103,8 @@ inThisBuild(
       WorkflowStep.Sbt(List("test"), name = Some("Run tests")),
       WorkflowStep.Sbt(List("doc"), name = Some("Build docs"))
     ),
+    isSnapshot :=
+      git.gitCurrentTags.value.isEmpty || git.gitUncommittedChanges.value,
     githubWorkflowPublishPostamble := Seq(
       WorkflowStep.Run(
         List("""
@@ -120,7 +122,7 @@ inThisBuild(
       )
     ),
     githubWorkflowPublishTargetBranches := Seq(
-      // RefPredicate.Equals(Ref.Branch("main")),
+      RefPredicate.Equals(Ref.Branch("main")),
       RefPredicate.StartsWith(Ref.Tag("v"))
     )
   )


### PR DESCRIPTION
Revert #341, by inlining the "original" definition of `isSnapshot` from sbt-git: https://github.com/sbt/sbt-git/blob/c97aca2577d8ca36d04859cb1bbcc6d8cdb0bece/src/main/scala/com/typesafe/sbt/SbtGit.scala#L187-L189