### PR TITLE
prepare CI for multi-branch setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: ['*']
+    branches: ['**']
   push:
-    branches: ['*']
+    branches: ['**']
     tags: [v*]
 
 env:
@@ -80,7 +80,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/series/') || startsWith(github.ref, 'refs/tags/v'))
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -116,6 +116,7 @@ jobs:
       - run: sbt ++${{ matrix.scala }} release
 
       - name: Publish docs
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           SBT_GHPAGES_COMMIT_MESSAGE: 'Updated site: sha=${{ github.sha }} build=${{ github.run_id }}'

--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,9 @@ inThisBuild(
     githubWorkflowArtifactUpload := false,
     githubWorkflowJavaVersions := Seq("adopt@1.11", "adopt@1.15"),
     githubWorkflowBuildMatrixFailFast := Some(false),
+    // "*" does not match slashes
+    // see https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+    githubWorkflowTargetBranches := Seq("**"),
     githubWorkflowBuild := Seq(
       WorkflowStep
         .Sbt(List("scalafmtCheckAll", "scalafmtSbtCheck"), name = Some("Check formatting")),
@@ -118,11 +121,13 @@ inThisBuild(
         env = Map(
           "SSH_PRIVATE_KEY" -> "${{ secrets.SSH_PRIVATE_KEY }}",
           "SBT_GHPAGES_COMMIT_MESSAGE" -> "Updated site: sha=${{ github.sha }} build=${{ github.run_id }}"
-        )
+        ),
+        cond = Some("github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')")
       )
     ),
     githubWorkflowPublishTargetBranches := Seq(
       RefPredicate.Equals(Ref.Branch("main")),
+      RefPredicate.StartsWith(Ref.Branch("series/")),
       RefPredicate.StartsWith(Ref.Tag("v"))
     )
   )


### PR DESCRIPTION
 - actually run in *all* branches (@rossabaker noticed this in http4s)
 - do not publish documentation for snapshots on the `series/*` branches