### PR TITLE
append -SNAPSHOT to version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,6 +108,11 @@ inThisBuild(
     ),
     isSnapshot :=
       git.gitCurrentTags.value.filter(_ != "").isEmpty || git.gitUncommittedChanges.value,
+    version := {
+      val v = version.value
+      val suffix = "-SNAPSHOT"
+      if (isSnapshot.value && !v.endsWith(suffix)) v + suffix else v
+    },
     githubWorkflowPublishPostamble := Seq(
       WorkflowStep.Run(
         List("""


### PR DESCRIPTION
It turns out that (contrary to the documentation in the README), sbt-sonatype actually checks for the `-SNAPSHOT` suffix...

https://github.com/xerial/sbt-sonatype/blob/2f148bf1cbaf56fbf8a2534d9947305670dcd3f7/src/main/scala/xerial/sbt/Sonatype.scala#L110

Sorry for the CI PR churn!