### PR TITLE
Shift Immediately After The F.async Call

### DIFF
--- a/core/src/main/scala/org/http4s/client/jdkhttpclient/package.scala
+++ b/core/src/main/scala/org/http4s/client/jdkhttpclient/package.scala
@@ -48,7 +48,7 @@ package object jdkhttpclient {
             case ex => cb(Left(ex))
           }
         }; ();
-      }
+      }.guarantee(CS.shift)
     }((cs, ec) =>
       (ec match {
         case ExitCase.Completed => F.unit
@@ -56,6 +56,6 @@ package object jdkhttpclient {
           F.delay(cs.completeExceptionally(e))
         case ExitCase.Canceled =>
           F.delay(cs.cancel(true))
-      }).void.guarantee(CS.shift)
+      }).void
     )
 }


### PR DESCRIPTION
We need to shift _immediately_ after the `F.async` call.