### PR TITLE
Update bundle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,10 +18,10 @@ lazy val docs = project
   .settings(libraryDependencies ++= blazeServer)
 
 val catsV = "2.7.0"
-val catsEffectV = "3.3.5"
-val fs2V = "3.2.4"
+val catsEffectV = "3.3.8"
+val fs2V = "3.2.5"
 val scodecV = "1.1.30"
-val http4sV = "0.23.10"
+val http4sV = "0.23.11"
 val reactiveStreamsV = "1.0.3"
 val vaultV = "3.1.0"
 val caseInsensitiveV = "1.2.0"

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ following dependency to your `build.sbt`:
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.http4s" %% "http4s-jdk-http-client" % "@SNAPSHOT_VERSION@"
+  "org.http4s" %% "http4s-jdk-http-client" % "@VERSION@"
 )
 ```
 
@@ -186,7 +186,7 @@ val echoServer = BlazeServerBuilder[IO]
   .map(s => s.baseUri.copy(scheme = scheme"ws".some))
 ```
 
-```scala
+```scala mdoc
 echoServer.use { echoUri =>
   webSocket
     .connectHighLevel(WSRequest(echoUri))

--- a/docs/README.md
+++ b/docs/README.md
@@ -131,7 +131,7 @@ using an `HttpClient` as above. It is encouraged to use the same `HttpClient`
 to construct a `Client[F]` and a `WSClient[F]`.
 
 ```scala mdoc
-// import org.http4s.client.websocket._
+import org.http4s.client.websocket._
 import org.http4s.jdkhttpclient._
 
 val (http, webSocket) =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.http4s" % "sbt-http4s-org" % "0.12.2")
+addSbtPlugin("org.http4s" % "sbt-http4s-org" % "0.13.0")


### PR DESCRIPTION
Closes https://github.com/http4s/http4s-jdk-http-client/issues/589. Supersedes https://github.com/http4s/http4s-jdk-http-client/pull/588.

Bundles a bunch of updates and fixes up the docs for a v0.7.0 release :)