### PR TITLE
Use Cats Effect EC as `HttpClient` executor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,8 @@ lazy val core = project
     name := "http4s-jdk-http-client",
     libraryDependencies ++= coreDeps,
     mimaBinaryIssueFilters ++= Seq(
+      // package private, due to #641
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
-        // package private, due to #641
         "org.http4s.jdkhttpclient.JdkHttpClient.defaultHttpClient"
       )
     )

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import com.typesafe.tools.mima.core._
+
 lazy val root = project
   .in(file("."))
   .enablePlugins(NoPublishPlugin)
@@ -7,7 +9,13 @@ lazy val core = project
   .in(file("core"))
   .settings(
     name := "http4s-jdk-http-client",
-    libraryDependencies ++= coreDeps
+    libraryDependencies ++= coreDeps,
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        // package private, due to #641
+        "org.http4s.jdkhttpclient.JdkHttpClient.defaultHttpClient"
+      )
+    )
   )
 
 lazy val docs = project

--- a/core/src/main/scala/org/http4s/jdkhttpclient/JdkHttpClient.scala
+++ b/core/src/main/scala/org/http4s/jdkhttpclient/JdkHttpClient.scala
@@ -265,7 +265,7 @@ object JdkHttpClient {
 
         ec match {
           case exec: util.concurrent.Executor => builder.executor(exec)
-          case _ => builder.executor(ec.execute)
+          case _ => builder.executor(ec.execute(_))
         }
 
         builder.build()

--- a/core/src/main/scala/org/http4s/jdkhttpclient/JdkHttpClient.scala
+++ b/core/src/main/scala/org/http4s/jdkhttpclient/JdkHttpClient.scala
@@ -252,16 +252,24 @@ object JdkHttpClient {
   def simple[F[_]](implicit F: Async[F]): Resource[F, Client[F]] =
     Resource.eval(defaultHttpClient[F]).flatMap(apply(_))
 
-  private[jdkhttpclient] def defaultHttpClient[F[_]](implicit F: Sync[F]): F[HttpClient] =
-    F.delay {
-      val builder = HttpClient.newBuilder()
-      // workaround for https://github.com/http4s/http4s-jdk-http-client/issues/200
-      if (Runtime.version().feature() == 11) {
-        val params = javax.net.ssl.SSLContext.getDefault().getDefaultSSLParameters()
-        params.setProtocols(params.getProtocols().filter(_ != "TLSv1.3"))
-        builder.sslParameters(params)
+  private[jdkhttpclient] def defaultHttpClient[F[_]](implicit F: Async[F]): F[HttpClient] =
+    F.executionContext.flatMap { ec =>
+      F.delay {
+        val builder = HttpClient.newBuilder()
+        // workaround for https://github.com/http4s/http4s-jdk-http-client/issues/200
+        if (Runtime.version().feature() == 11) {
+          val params = javax.net.ssl.SSLContext.getDefault().getDefaultSSLParameters()
+          params.setProtocols(params.getProtocols().filter(_ != "TLSv1.3"))
+          builder.sslParameters(params)
+        }
+
+        ec match {
+          case exec: util.concurrent.Executor => builder.executor(exec)
+          case _ => builder.executor(ec.execute)
+        }
+
+        builder.build()
       }
-      builder.build()
     }
 
   def convertHttpVersionFromHttp4s[F[_]](

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,11 +63,14 @@ in an effect, as it creates a default executor and SSL context:
 import java.net.{InetSocketAddress, ProxySelector}
 import java.net.http.HttpClient
 
-val client0: Resource[IO, Client[IO]] = Resource.eval(IO {
-  HttpClient.newBuilder()
-    .version(HttpClient.Version.HTTP_2)
-    .proxy(ProxySelector.of(new InetSocketAddress("www-proxy", 8080)))
-    .build()
+val client0: Resource[IO, Client[IO]] = Resource.eval(IO.executionContext.flatMap { ec =>
+  IO {
+    HttpClient.newBuilder()
+      .version(HttpClient.Version.HTTP_2)
+      .proxy(ProxySelector.of(new InetSocketAddress("www-proxy", 8080)))
+      .executor(ec.execute(_))
+      .build()
+  }
 }).flatMap(JdkHttpClient(_))
 ```
 


### PR DESCRIPTION
I'm not 100% sure on this change yet, but I'm pretty sure this executor is not used for blocking operations. In which case, we should definitely prefer to use the Cats Effect compute pool here. It means one less threadpool in the application and thus less contention and less page faults, which is a big win.

```java
        /**
         * Sets the executor to be used for asynchronous and dependent tasks.
         *
         * <p> If this method is not invoked prior to {@linkplain #build()
         * building}, a default executor is created for each newly built {@code
         * HttpClient}.
```

https://github.com/openjdk/jdk11/blob/37115c8ea4aff13a8148ee2b8832b20888a5d880/src/java.net.http/share/classes/java/net/http/HttpClient.java#L253