### PR TITLE
Migrate to ember

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val docs = project
   .enablePlugins(Http4sOrgSitePlugin)
   .dependsOn(core)
   .settings(docsSettings)
-  .settings(libraryDependencies ++= blazeServer)
+  .settings(libraryDependencies ++= emberServer)
 
 ThisBuild / mergifyStewardConfig := Some(
   MergifyStewardConfig(action = MergifyAction.Merge(method = Some("squash")))
@@ -44,8 +44,8 @@ val munitV = "0.7.29"
 val munitCatsEffectV = "1.0.7"
 val javaWebsocketV = "1.5.3"
 
-val blazeServer = Seq(
-  "org.http4s" %% "http4s-blaze-server" % http4sV,
+val emberServer = Seq(
+  "org.http4s" %% "http4s-ember-server" % http4sV,
   "org.http4s" %% "http4s-dsl" % http4sV
 )
 
@@ -62,7 +62,7 @@ val coreDeps = Seq(
   "org.scodec" %% "scodec-bits" % scodecV,
   "org.typelevel" %% "vault" % vaultV,
   "org.typelevel" %% "case-insensitive" % caseInsensitiveV
-) ++ (blazeServer ++ Seq(
+) ++ (emberServer ++ Seq(
   "org.java-websocket" % "Java-WebSocket" % javaWebsocketV,
   "org.scalameta" %% "munit" % munitV,
   "org.typelevel" %% "munit-cats-effect-3" % munitCatsEffectV

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,6 @@ val caseInsensitiveV = "1.3.0"
 
 val munitV = "1.0.0-M6"
 val munitCatsEffectV = "2.0.0-M3"
-val javaWebsocketV = "1.5.3"
 
 val emberServer = Seq(
   "org.http4s" %% "http4s-ember-server" % http4sV,
@@ -67,7 +66,6 @@ val coreDeps = Seq(
   "org.typelevel" %% "case-insensitive" % caseInsensitiveV
 ) ++ (emberServer ++ Seq(
   "org.http4s" %% "http4s-client-testkit" % http4sV,
-  "org.java-websocket" % "Java-WebSocket" % javaWebsocketV,
   "org.scalameta" %% "munit" % munitV,
   "org.typelevel" %% "munit-cats-effect" % munitCatsEffectV
 )).map(_ % Test)

--- a/core/src/test/scala/org/http4s/jdkhttpclient/BodyLeakExample.scala
+++ b/core/src/test/scala/org/http4s/jdkhttpclient/BodyLeakExample.scala
@@ -19,9 +19,10 @@ package org.http4s.jdkhttpclient
 import cats.data._
 import cats.effect._
 import cats.syntax.all._
+import com.comcast.ip4s._
 import org.http4s._
 import org.http4s.client._
-import org.http4s.blaze.server.BlazeServerBuilder
+import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.syntax.all._
 
 // This is a *manual* test for the body leak fixed in #335
@@ -45,10 +46,11 @@ object BodyLeakExample extends IOApp {
       )
 
   override def run(args: List[String]): IO[ExitCode] =
-    BlazeServerBuilder[IO]
-      .bindLocal(8080)
+    EmberServerBuilder
+      .default[IO]
+      .withPort(port"8080")
       .withHttpApp(app)
-      .resource
+      .build
       .product(JdkHttpClient.simple[IO])
       .use { case (_, client) =>
         for {

--- a/core/src/test/scala/org/http4s/jdkhttpclient/CompletableFutureTerminationTest.scala
+++ b/core/src/test/scala/org/http4s/jdkhttpclient/CompletableFutureTerminationTest.scala
@@ -29,10 +29,11 @@ import cats.data._
 import cats.effect._
 import cats.effect.std.Semaphore
 import cats.syntax.all._
+import com.comcast.ip4s._
 import munit.CatsEffectSuite
 import org.http4s._
 import org.http4s.server._
-import org.http4s.blaze.server._
+import org.http4s.ember.server._
 
 final class CompletableFutureTerminationTest extends CatsEffectSuite {
   import CompletableFutureTerminationTest._
@@ -175,7 +176,8 @@ object CompletableFutureTerminationTest {
       semaphore: Semaphore[F],
       gotRequest: Semaphore[F]
   )(implicit F: Async[F]): Resource[F, Server] =
-    BlazeServerBuilder[F]
+    EmberServerBuilder
+      .default[F]
       .withHttpApp(
         Kleisli(
           Function.const(
@@ -184,8 +186,8 @@ object CompletableFutureTerminationTest {
           )
         )
       )
-      .bindAny()
-      .resource
+      .withPort(port"0")
+      .build
 
   /** Just a scala wrapper class to make it easier to generate a [[java.util.function.BiFunction]].
     */

--- a/core/src/test/scala/org/http4s/jdkhttpclient/CompletableFutureTerminationTest.scala
+++ b/core/src/test/scala/org/http4s/jdkhttpclient/CompletableFutureTerminationTest.scala
@@ -185,6 +185,7 @@ object CompletableFutureTerminationTest {
           )
         )
       )
+      .withShutdownTimeout(1.second)
       .withPort(port"0")
       .build
 

--- a/core/src/test/scala/org/http4s/jdkhttpclient/JdkWSClientSpec.scala
+++ b/core/src/test/scala/org/http4s/jdkhttpclient/JdkWSClientSpec.scala
@@ -75,7 +75,7 @@ class JdkWSClientSpec extends CatsEffectSuite {
           WSFrame.Text("bar"),
           WSFrame.Binary(ByteVector(3, 99, 12)),
           WSFrame.Text("foo"),
-          WSFrame.Close(1000, "goodbye")
+          WSFrame.Close(1000, "")
         )
       )
   }

--- a/core/src/test/scala/org/http4s/jdkhttpclient/JdkWSClientSpec.scala
+++ b/core/src/test/scala/org/http4s/jdkhttpclient/JdkWSClientSpec.scala
@@ -148,18 +148,18 @@ class JdkWSClientSpec extends CatsEffectSuite {
         .build
         .map(s => WSRequest(httpToWsUri(s.baseUri)))
       _ <- server.use { req =>
-        webSocket().connect(req).use(conn => conn.send(WSFrame.Text("hi blaze"))) *>
+        webSocket().connect(req).use(conn => conn.send(WSFrame.Text("hi ember"))) *>
           webSocket().connectHighLevel(req).use { conn =>
-            conn.send(WSFrame.Text("hey blaze"))
+            conn.send(WSFrame.Text("hey ember"))
           }
       }
       frames <- ref.get
     } yield frames
     frames.assertEquals(
       List(
-        WebSocketFrame.Text("hi blaze"),
+        WebSocketFrame.Text("hi ember"),
         closeFrame,
-        WebSocketFrame.Text("hey blaze"),
+        WebSocketFrame.Text("hey ember"),
         closeFrame
       )
     )

--- a/docs/README.md
+++ b/docs/README.md
@@ -186,13 +186,14 @@ We use the "high-level" connection mode to build a simple websocket app.
 ```scala mdoc:invisible
 import org.http4s.dsl.io._
 import org.http4s.implicits._
-import org.http4s.blaze.server.BlazeServerBuilder
-val echoServer = BlazeServerBuilder[IO]
-  .bindAny()
+import org.http4s.ember.server.EmberServerBuilder
+import com.comcast.ip4s._
+val echoServer = EmberServerBuilder.default[IO]
+  .withPort(port"0")
   .withHttpWebSocketApp(wsb => HttpRoutes.of[IO] {
     case GET -> Root => wsb.build(identity)
   }.orNotFound)
-  .resource
+  .build
   .map(s => s.baseUri.copy(scheme = scheme"ws".some))
 ```
 


### PR DESCRIPTION
Now that blaze is schismed, the dependency is more of a burden here. This is especially a problem on main, because it means the jdk-http-client is blocked from updating to the latest http4s milestone until blaze itself has updated and released, which may not be straightforward.