### PR TITLE
Update http4s to v1.0.0-M33

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,7 @@ val coreDeps = Seq(
   "org.typelevel" %% "vault" % vaultV,
   "org.typelevel" %% "case-insensitive" % caseInsensitiveV
 ) ++ (blazeServer ++ Seq(
+  "org.http4s" %% "http4s-client-testkit" % http4sV,
   "org.java-websocket" % "Java-WebSocket" % javaWebsocketV,
   "org.scalameta" %% "munit" % munitV,
   "org.typelevel" %% "munit-cats-effect-3" % munitCatsEffectV

--- a/build.sbt
+++ b/build.sbt
@@ -35,18 +35,19 @@ val catsV = "2.7.0"
 val catsEffectV = "3.3.12"
 val fs2V = "3.2.7"
 val scodecV = "1.1.31"
-val http4sV = "1.0.0-M32"
+val http4sV = "1.0.0-M33"
 val reactiveStreamsV = "1.0.3"
 val vaultV = "3.1.0"
 val caseInsensitiveV = "1.2.0"
 
+val http4sBlazeV = "1.0.0-M33"
 val munitV = "0.7.29"
 val munitCatsEffectV = "1.0.7"
 val javaWebsocketV = "1.5.3"
 
 val blazeServer = Seq(
-  "org.http4s" %% "http4s-blaze-server" % http4sV,
-  "org.http4s" %% "http4s-dsl" % http4sV
+  "org.http4s" %% "http4s-blaze-server" % http4sBlazeV,
+  "org.http4s" %% "http4s-dsl" % http4sBlazeV
 )
 
 val coreDeps = Seq(

--- a/core/src/test/scala/org/http4s/jdkhttpclient/JdkHttpClientSpec.scala
+++ b/core/src/test/scala/org/http4s/jdkhttpclient/JdkHttpClientSpec.scala
@@ -14,14 +14,29 @@
  * limitations under the License.
  */
 
-// TODO uncomment in the future
-/*
 package org.http4s.jdkhttpclient
 
 import cats.effect._
-import org.http4s.client.ClientRouteTestBattery
+import org.http4s.Header
+import org.http4s.Request
+import org.http4s.Uri
+import org.http4s.client.testkit.ClientRouteTestBattery
+import org.typelevel.ci._
+import org.http4s.client.testkit.testroutes.GetRoutes
 
 class JdkHttpClientSpec extends ClientRouteTestBattery("JdkHttpClient") {
-  def clientResource = Resource.liftF(JdkHttpClient.simple[IO])
+  def clientResource = JdkHttpClient.simple[IO]
+
+  // regression test for https://github.com/http4s/http4s-jdk-http-client/issues/395
+  test("Don't error with empty body and explicit Content-Length: 0") {
+    serverClient().flatMap { case (server, client) =>
+      val address = server().addresses.head
+      val path = GetRoutes.SimplePath
+      val uri = Uri.fromString(s"http://$address$path").toOption.get
+      val req: Request[IO] = Request(uri = uri)
+        .putHeaders(Header.Raw(ci"Content-Length", "0"))
+      val body = client().expect[String](req)
+      body.assertEquals("simple path")
+    }
+  }
 }
- */


### PR DESCRIPTION
This also includes a merge from [`series/0.7`](https://github.com/http4s/http4s-jdk-http-client/tree/series/0.7).