### PR TITLE
Update changelog for v1.0.0-M3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This file summarizes **notable** changes for each release, but does not describe
 
 ----
 
+## v1.0.0-M3 (2022-07-07)
+
+### Dependency updates
+
+* cats-2.8.0
+* **http4s-1.0.0-M34**
+
 ## v1.0.0-M2 (2022-05-31)
 
 ### Improvements


### PR DESCRIPTION
I think it makes sense to stop listing dependency patch bumps.