### PR TITLE
Migrate to new FS2 `j.u.c.Flow` interop APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,15 +114,15 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}' unusedCompileDependenciesTest
 
       - name: Make target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.8')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.9')
         run: mkdir -p target core/target site/target project/target
 
       - name: Compress target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.8')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.9')
         run: tar cf targets.tar target core/target site/target project/target
 
       - name: Upload target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.8')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.9')
         uses: actions/upload-artifact@v3
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}
@@ -131,7 +131,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.8')
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.9')
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -294,7 +294,7 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}' docs/tlSite
 
       - name: Publish site
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/series/0.8'
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/series/0.9'
         uses: peaceiris/actions-gh-pages@v3.9.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,18 +91,18 @@ jobs:
         run: sbt githubWorkflowCheck
 
       - name: Check headers and formatting
-        if: matrix.java == 'temurin@11'
+        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-latest'
         run: sbt '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
       - name: Test
         run: sbt '++ ${{ matrix.scala }}' test
 
       - name: Check binary compatibility
-        if: matrix.java == 'temurin@11'
+        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-latest'
         run: sbt '++ ${{ matrix.scala }}' mimaReportBinaryIssues
 
       - name: Generate API documentation
-        if: matrix.java == 'temurin@11'
+        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-latest'
         run: sbt '++ ${{ matrix.scala }}' doc
 
       - name: Check scalafix lints
@@ -295,7 +295,7 @@ jobs:
 
       - name: Publish site
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/series/0.8'
-        uses: peaceiris/actions-gh-pages@v3.8.0
+        uses: peaceiris/actions-gh-pages@v3.9.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: site/target/docs/site

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ ThisBuild / mergifyLabelPaths += "docs" -> file("docs")
 
 val catsV = "2.9.0"
 val catsEffectV = "3.4.4"
-val fs2V = "3.4.0"
+val fs2V = "3.4.0-59-7543784-SNAPSHOT"
 val scodecV = "1.1.34"
 val http4sV = "0.23.17"
 val reactiveStreamsV = "1.0.4"
@@ -57,10 +57,8 @@ val coreDeps = Seq(
   "org.typelevel" %% "cats-effect-kernel" % catsEffectV,
   "org.typelevel" %% "cats-effect-std" % catsEffectV,
   "co.fs2" %% "fs2-core" % fs2V,
-  "co.fs2" %% "fs2-reactive-streams" % fs2V,
   "org.http4s" %% "http4s-client" % http4sV,
   "org.http4s" %% "http4s-core" % http4sV,
-  "org.reactivestreams" % "reactive-streams" % reactiveStreamsV,
   "org.scodec" %% "scodec-bits" % scodecV,
   "org.typelevel" %% "vault" % vaultV,
   "org.typelevel" %% "case-insensitive" % caseInsensitiveV
@@ -70,10 +68,12 @@ val coreDeps = Seq(
   "org.typelevel" %% "munit-cats-effect" % munitCatsEffectV
 )).map(_ % Test)
 
+ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
+
 val scala213 = "2.13.10"
 ThisBuild / crossScalaVersions := Seq("2.12.17", scala213, "3.2.1")
 ThisBuild / scalaVersion := scala213
-ThisBuild / tlBaseVersion := "0.8"
+ThisBuild / tlBaseVersion := "0.9"
 ThisBuild / startYear := Some(2019)
 ThisBuild / developers := List(
   tlGitHubDev("ChristopherDavenport", "Christopher Davenport"),

--- a/build.sbt
+++ b/build.sbt
@@ -81,8 +81,8 @@ ThisBuild / developers := List(
 
 ThisBuild / tlJdkRelease := Some(11)
 ThisBuild / githubWorkflowJavaVersions := Seq("11", "17").map(JavaSpec.temurin(_))
-ThisBuild / tlCiReleaseBranches := Seq("series/0.8")
-ThisBuild / tlSitePublishBranch := Some("series/0.8")
+ThisBuild / tlCiReleaseBranches := Seq("series/0.9")
+ThisBuild / tlSitePublishBranch := Some("series/0.9")
 
 lazy val docsSettings =
   Seq(
@@ -92,8 +92,9 @@ lazy val docsSettings =
       import laika.rewrite._
       _.site.versions(
         Versions(
-          currentVersion = Version("0.8.x", "0.8"),
+          currentVersion = Version("0.9.x", "0.9"),
           olderVersions = Seq(
+            Version("0.8.x", "0.8"),
             Version("0.7.x", "0.7"),
             Version("0.6.x", "0.6.0-M7"),
             Version("0.5.x", "0.5.0"),

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ ThisBuild / mergifyLabelPaths += "docs" -> file("docs")
 
 val catsV = "2.9.0"
 val catsEffectV = "3.4.4"
-val fs2V = "3.4.0-59-7543784-SNAPSHOT"
+val fs2V = "3.5.0-7-87bd1e4-SNAPSHOT"
 val scodecV = "1.1.34"
 val http4sV = "0.23.17"
 val reactiveStreamsV = "1.0.4"

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ ThisBuild / mergifyLabelPaths += "docs" -> file("docs")
 
 val catsV = "2.9.0"
 val catsEffectV = "3.4.5"
-val fs2V = "3.5.0-7-87bd1e4-SNAPSHOT"
+val fs2V = "3.5.0-12-6d1e0b0-SNAPSHOT"
 val scodecV = "1.1.34"
 val http4sV = "0.23.17"
 val reactiveStreamsV = "1.0.4"

--- a/core/src/main/scala/org/http4s/jdkhttpclient/JdkHttpClient.scala
+++ b/core/src/main/scala/org/http4s/jdkhttpclient/JdkHttpClient.scala
@@ -23,7 +23,7 @@ import cats.implicits._
 import fs2.Chunk
 import fs2.Stream
 import fs2.concurrent.SignallingRef
-import fs2.interop.reactivestreams._
+import fs2.interop.flow._
 import org.http4s.Header
 import org.http4s.Headers
 import org.http4s.HttpVersion
@@ -32,7 +32,6 @@ import org.http4s.Response
 import org.http4s.Status
 import org.http4s.client.Client
 import org.http4s.internal.CollectionCompat.CollectionConverters._
-import org.reactivestreams.FlowAdapters
 import org.typelevel.ci.CIString
 
 import java.net.URI
@@ -61,18 +60,17 @@ object JdkHttpClient {
       ignoredHeaders: Set[CIString] = restrictedHeaders
   )(implicit F: Async[F]): Client[F] = {
     def convertRequest(req: Request[F]): Resource[F, HttpRequest] =
-      StreamUnicastPublisher(req.body.chunks.map(_.toByteBuffer)).evalMap { publisher =>
+      req.body.chunks.map(_.toByteBuffer).toPublisher.evalMap { publisher =>
         convertHttpVersionFromHttp4s[F](req.httpVersion).map { version =>
           val rb = HttpRequest.newBuilder
             .method(
               req.method.name, {
-                val flowPublisher = FlowAdapters.toFlowPublisher(publisher)
                 if (req.isChunked)
-                  BodyPublishers.fromPublisher(flowPublisher)
+                  BodyPublishers.fromPublisher(publisher)
                 else
                   req.contentLength match {
                     case Some(length) if length > 0L =>
-                      BodyPublishers.fromPublisher(flowPublisher, length)
+                      BodyPublishers.fromPublisher(publisher, length)
                     case _ => BodyPublishers.noBody
                   }
               }
@@ -194,6 +192,7 @@ object JdkHttpClient {
         }
         .flatMap { case (subscription, res) =>
           val body: Stream[F, util.List[ByteBuffer]] =
+            res.body.toStream(1)
             Stream
               .eval(StreamSubscriber[F, util.List[ByteBuffer]](1))
               .flatMap(s =>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<meta http-equiv="refresh" content="0; URL=0.8">
-<link rel="canonical" href="0.8">
+<meta http-equiv="refresh" content="0; URL=0.9">
+<link rel="canonical" href="0.9">

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.http4s" % "sbt-http4s-org" % "0.14.9")
+addSbtPlugin("org.http4s" % "sbt-http4s-org" % "0.14.10")
 addSbtPlugin("org.typelevel" % "sbt-typelevel-mergify" % "0.4.18")


### PR DESCRIPTION
Upstream PR:
- https://github.com/typelevel/fs2/pull/3102

Previously interop was done through the reactive-streams converter, but now FS2 can interop directly with the JDK9+ interfaces. So we can remove a layer of cruft 😆 