### PR TITLE
Add hard abort on resource closure if any part of the stream remains open

### DIFF
--- a/core/src/main/scala/org/http4s/jdkhttpclient/JdkWSClient.scala
+++ b/core/src/main/scala/org/http4s/jdkhttpclient/JdkWSClient.scala
@@ -129,6 +129,15 @@ object JdkWSClient {
                       })
                     } yield ()
                   }
+
+              shouldAbort <- F.delay {
+                !webSocket.isOutputClosed || !webSocket.isInputClosed
+              }
+
+              _ <- if(shouldAbort) F.delay {
+                webSocket.abort()
+              } else F.unit
+
             } yield ()
           }
           .map { case (webSocket, queue, closedDef, sendSem) =>


### PR DESCRIPTION
Background of this MR is that we observed leaked sockets that eventually caused our application to crash due to exhausted file handles. Granted we use websockets a bit weirdly by having them only open a short time rather than long which probably caused this problem to show up in the first place. For more background information see: https://discord.com/channels/632277896739946517/632286375311573032/1091349652579827783

Sadly I was unable to minimize an example due to time constraint but some wireshark debugging showed the following. 

This is a healthy package exchange where all sockets in both applications (server and client) are torn down and cleaned up properly:

![image](https://user-images.githubusercontent.com/2368458/233041954-c14235f9-c9d1-4a62-af96-b524f8c80e35.png)

This is an unhealthy one:

![image](https://user-images.githubusercontent.com/2368458/233042067-797e7b9e-326e-4ec6-9577-fc9114ca1d2e.png)

Note that in both cases on the websocket protocol layer, close frames are exchanged properly. However in some (yet unidentified, I suspect concurrency, as the only way i was able to reproduce this is by concurrently firing many requests) cirumstances the server does not respond with a TCP FIN/ACK. 

With a blaze server this also leads to CLOSE_WAIT sockets on the server, ember seems to handles this properly as of 0.29-RC3 with the EoS fix. 

With both servers the JDK client then remains in a half open state with the server side stream remaining open. This MR checks if any side remains open in the tear down of the resource and in such a case aborts the connection. It's a bit of a sledgehammer solution but i couldn't figure out why the TCP frames are missing and this is at least a bandaid. 

The problem gets much worse if proxies are involved as the half-open state of the socket also causes the tunneling connection to remain open leading to an explosion in allocated socket that are only eventually somewhat cleaned up by JDK https internal pool handling. 

This is possibly related to https://github.com/http4s/http4s/issues/4798 though I'm entirely unsure.