### PR TITLE
remove un/rewrapping of logic with Async in defaultHttpClient

### DIFF
--- a/core/src/main/scala/org/http4s/jdkhttpclient/JdkHttpClient.scala
+++ b/core/src/main/scala/org/http4s/jdkhttpclient/JdkHttpClient.scala
@@ -253,20 +253,18 @@ object JdkHttpClient {
     defaultHttpClient[F].map(apply(_))
 
   private[jdkhttpclient] def defaultHttpClient[F[_]](implicit F: Async[F]): F[HttpClient] =
-    F.executor.flatMap { exec =>
-      F.delay {
-        val builder = HttpClient.newBuilder()
-        // workaround for https://github.com/http4s/http4s-jdk-http-client/issues/200
-        if (Runtime.version().feature() == 11) {
-          val params = javax.net.ssl.SSLContext.getDefault().getDefaultSSLParameters()
-          params.setProtocols(params.getProtocols().filter(_ != "TLSv1.3"))
-          builder.sslParameters(params)
-        }
-
-        builder.executor(exec)
-
-        builder.build()
+    F.executor.map { exec =>
+      val builder = HttpClient.newBuilder()
+      // workaround for https://github.com/http4s/http4s-jdk-http-client/issues/200
+      if (Runtime.version().feature() == 11) {
+        val params = javax.net.ssl.SSLContext.getDefault().getDefaultSSLParameters()
+        params.setProtocols(params.getProtocols().filter(_ != "TLSv1.3"))
+        builder.sslParameters(params)
       }
+
+      builder.executor(exec)
+
+      builder.build()
     }
 
   def convertHttpVersionFromHttp4s[F[_]](


### PR DESCRIPTION
I think the 'flatMap' + subsequent 'F.delay' can be replaced by 'map'. Please correct me if I'm wrong.