### PR TITLE
Add Resource-based simple constructors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,16 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12, 2.13, 3]
-        java: [temurin@11, temurin@17]
+        java: [temurin@11, temurin@17, temurin@21]
         exclude:
           - scala: 2.12
             java: temurin@17
+          - scala: 2.12
+            java: temurin@21
           - scala: 3
             java: temurin@17
+          - scala: 3
+            java: temurin@21
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -68,6 +72,19 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
+        run: sbt +update
+
+      - name: Setup Java (temurin@21)
+        id: setup-java-temurin-21
+        if: matrix.java == 'temurin@21'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@21' && steps.setup-java-temurin-21.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Check that workflows are up to date
@@ -150,6 +167,19 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
+        run: sbt +update
+
+      - name: Setup Java (temurin@21)
+        id: setup-java-temurin-21
+        if: matrix.java == 'temurin@21'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@21' && steps.setup-java-temurin-21.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Download target directories (2.12)
@@ -246,6 +276,19 @@ jobs:
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt +update
 
+      - name: Setup Java (temurin@21)
+        id: setup-java-temurin-21
+        if: matrix.java == 'temurin@21'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@21' && steps.setup-java-temurin-21.outputs.cache-hit == 'false'
+        run: sbt +update
+
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
@@ -289,6 +332,19 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
+        run: sbt +update
+
+      - name: Setup Java (temurin@21)
+        id: setup-java-temurin-21
+        if: matrix.java == 'temurin@21'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@21' && steps.setup-java-temurin-21.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Generate site

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,6 +13,7 @@ pull_request_rules:
   - status-success=Build and Test (ubuntu-latest, 2.12, temurin@11)
   - status-success=Build and Test (ubuntu-latest, 2.13, temurin@11)
   - status-success=Build and Test (ubuntu-latest, 2.13, temurin@17)
+  - status-success=Build and Test (ubuntu-latest, 2.13, temurin@21)
   - status-success=Build and Test (ubuntu-latest, 3, temurin@11)
   - status-success=Generate Site (ubuntu-latest, temurin@11)
   actions:

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ ThisBuild / developers := List(
 )
 
 ThisBuild / tlJdkRelease := Some(11)
-ThisBuild / githubWorkflowJavaVersions := Seq("11", "17").map(JavaSpec.temurin(_))
+ThisBuild / githubWorkflowJavaVersions := Seq("11", "17", "21").map(JavaSpec.temurin(_))
 ThisBuild / tlCiReleaseBranches := Seq("series/0.9")
 ThisBuild / tlSitePublishBranch := Some("series/0.9")
 
@@ -109,8 +109,8 @@ lazy val docsSettings =
       "HTTP4S_VERSION_SHORT" -> http4sV.split("\\.").take(2).mkString("."),
       "SCALA_VERSION" -> CrossVersion.binaryScalaVersion(scalaVersion.value),
       "SCALA_VERSIONS" -> formatCrossScalaVersions((core / crossScalaVersions).value.toList)
-    ),
-    unusedCompileDependenciesFilter -= moduleFilter()
+    )
+    // unusedCompileDependenciesFilter -= moduleFilter()
   )
 
 def formatCrossScalaVersions(crossScalaVersions: List[String]): String = {

--- a/core/src/main/scala/org/http4s/jdkhttpclient/JdkHttpClient.scala
+++ b/core/src/main/scala/org/http4s/jdkhttpclient/JdkHttpClient.scala
@@ -243,9 +243,27 @@ object JdkHttpClient {
     * [[cats.effect.kernel.Async.executor executor]], sets the
     * [[org.http4s.client.defaults.ConnectTimeout default http4s connect timeout]], and disables
     * [[https://github.com/http4s/http4s-jdk-http-client/issues/200 TLS 1.3 on JDK 11]].
+    *
+    * On Java 21 and higher, prefer [[simpleResource]] as it actively closes the underlying client,
+    * releasing its resources early.
     */
   def simple[F[_]](implicit F: Async[F]): F[Client[F]] =
     defaultHttpClient[F].map(apply(_))
+
+  /** Like [[simple]], but wraps the client in a [[cats.effect.Resource Resource]] to ensure it's
+    * properly shut down on JVM 21 and higher. On lower Java versions, closing the resource does
+    * nothing (garbage collection will eventually clean up the client).
+    */
+  def simpleResource[F[_]](implicit F: Async[F]): Resource[F, Client[F]] =
+    defaultHttpClientResource[F].map(apply(_))
+
+  private[jdkhttpclient] def defaultHttpClientResource[F[_]](implicit
+      F: Async[F]
+  ): Resource[F, HttpClient] =
+    Resource.make[F, HttpClient](defaultHttpClient[F]) {
+      case c: AutoCloseable => Sync[F].blocking(c.close())
+      case _ => Applicative[F].unit
+    }
 
   private[jdkhttpclient] def defaultHttpClient[F[_]](implicit F: Async[F]): F[HttpClient] =
     F.executor.flatMap { exec =>

--- a/core/src/test/scala/org/http4s/jdkhttpclient/JdkHttpClientSpec.scala
+++ b/core/src/test/scala/org/http4s/jdkhttpclient/JdkHttpClientSpec.scala
@@ -28,7 +28,7 @@ import org.typelevel.ci._
 import scala.concurrent.duration._
 
 class JdkHttpClientSpec extends ClientRouteTestBattery("JdkHttpClient") {
-  def clientResource: Resource[IO, Client[IO]] = Resource.eval(JdkHttpClient.simple[IO])
+  def clientResource: Resource[IO, Client[IO]] = JdkHttpClient.simpleResource[IO]
 
   // regression test for https://github.com/http4s/http4s-jdk-http-client/issues/395
   test("Don't error with empty body and explicit Content-Length: 0") {

--- a/core/src/test/scala/org/http4s/jdkhttpclient/JdkWSClientSpec.scala
+++ b/core/src/test/scala/org/http4s/jdkhttpclient/JdkWSClientSpec.scala
@@ -36,7 +36,7 @@ import scala.concurrent.duration._
 class JdkWSClientSpec extends CatsEffectSuite {
 
   val webSocket: IOFixture[WSClient[IO]] =
-    ResourceSuiteLocalFixture("webSocket", Resource.eval(JdkWSClient.simple[IO]))
+    ResourceSuiteLocalFixture("webSocket", JdkWSClient.simpleResource[IO])
   val echoServerUri: IOFixture[Uri] =
     ResourceSuiteLocalFixture(
       "echoServerUri",


### PR DESCRIPTION
As Java 21+ allows explicitly closing clients, this adds new constructors that return the clients wrapped in a `Resource`. On older Java versions, the release is a no-op, on newer it enforces the cleanup of resources.

Also ensures the websocket client closes the input channel on release so the connection gets properly closed.

Closes #1011